### PR TITLE
TFP-890 oppdater test siden 5027 ikke skal re-overstyres i revurdering

### DIFF
--- a/src/test/java/no/nav/foreldrepenger/autotest/foreldrepenger/foreldrepenger/MorOgFarSammen.java
+++ b/src/test/java/no/nav/foreldrepenger/autotest/foreldrepenger/foreldrepenger/MorOgFarSammen.java
@@ -408,10 +408,6 @@ public class MorOgFarSammen extends ForeldrepengerTestBase {
         saksbehandler.opprettBehandlingRevurdering("RE-FRDLING");
         saksbehandler.velgRevurderingBehandling();
 
-        saksbehandler.hentAksjonspunktbekreftelse(VurderManglendeFodselBekreftelse.class)
-            .bekreftDokumentasjonForeligger(1, fødselsdato);
-        saksbehandler.bekreftAksjonspunktBekreftelse(VurderManglendeFodselBekreftelse.class);
-
         saksbehandler.hentAksjonspunktbekreftelse(KontrollerOpplysningerOmFordelingAvStonadsperioden.class)
             .godkjennAllePerioder();
         saksbehandler.bekreftAksjonspunktBekreftelse(KontrollerOpplysningerOmFordelingAvStonadsperioden.class);
@@ -426,8 +422,7 @@ public class MorOgFarSammen extends ForeldrepengerTestBase {
         beslutter.velgRevurderingBehandling();
 
         beslutter.hentAksjonspunktbekreftelse(FatterVedtakBekreftelse.class)
-            .godkjennAksjonspunkt(beslutter.hentAksjonspunkt(AksjonspunktKoder.KONTROLLER_OPPLYSNINGER_OM_FORDELING_AV_STØNADSPERIODEN))
-            .godkjennAksjonspunkt(beslutter.hentAksjonspunkt(AksjonspunktKoder.SJEKK_MANGLENDE_FØDSEL));
+            .godkjennAksjonspunkt(beslutter.hentAksjonspunkt(AksjonspunktKoder.KONTROLLER_OPPLYSNINGER_OM_FORDELING_AV_STØNADSPERIODEN));
         beslutter.fattVedtakOgVentTilAvsluttetBehandling();
     }
 


### PR DESCRIPTION
890 ble gjort fordi man ikke ønsker 5027 i hver revurdering for dnr/utlandssaker der barn ikke er i tps eller mangler relasjon
Overstyring av manglende fødsel i førstegang/revurdering huskes i senere revurderinger