### PR TITLE
NOJIRA Justerer refusjon i test for å unngå automatisk omfordeling av…

### DIFF
--- a/src/test/java/no/nav/foreldrepenger/autotest/foreldrepenger/foreldrepenger/Fodsel.java
+++ b/src/test/java/no/nav/foreldrepenger/autotest/foreldrepenger/foreldrepenger/Fodsel.java
@@ -101,7 +101,7 @@ public class Fodsel extends ForeldrepengerTestBase {
         int inntektPerMåned = 20_000;
         int overstyrtInntekt = 500_000;
         int overstyrtFrilanserInntekt = 500_000;
-        BigDecimal refusjon = BigDecimal.valueOf(overstyrtInntekt + overstyrtFrilanserInntekt);
+        BigDecimal refusjon = BigDecimal.valueOf(overstyrtInntekt/12);
 
         Opptjening opptjening = OpptjeningErketyper.medFrilansOpptjening();
         ForeldrepengerBuilder søknad = lagSøknadForeldrepengerTermin(fødselsdato, søkerAktørIdent, SøkersRolle.MOR)


### PR DESCRIPTION
… beregningsgrunnlag.

Testen oppgav tidligere at refusjonskravet pr mnd var lik den samla årsinntekten frå frilans og arbeid, noko som ikkje er eit veldig reelt scenario.