### PR TITLE
FIX: Fikser mottattDato for søknad og fjerner instansiering av propertyfiler.

### DIFF
--- a/src/main/java/no/nav/foreldrepenger/autotest/base/FpsakTestBase.java
+++ b/src/main/java/no/nav/foreldrepenger/autotest/base/FpsakTestBase.java
@@ -1,9 +1,10 @@
 package no.nav.foreldrepenger.autotest.base;
 
+import org.junit.jupiter.api.BeforeEach;
+
 import no.nav.foreldrepenger.autotest.aktoerer.fordel.Fordel;
 import no.nav.foreldrepenger.autotest.aktoerer.foreldrepenger.Saksbehandler;
 import no.nav.foreldrepenger.autotest.klienter.fpsak.kodeverk.dto.Kodeverk;
-import org.junit.jupiter.api.BeforeEach;
 
 public class FpsakTestBase extends TestScenarioTestBase {
 
@@ -16,13 +17,6 @@ public class FpsakTestBase extends TestScenarioTestBase {
     protected Saksbehandler beslutter;
     protected Saksbehandler klagebehandler;
 
-    /*
-     * VTP
-     */
-//    protected SøknadForeldrepengeErketyper foreldrepengeSøknadErketyper;
-//    protected InntektsmeldingErketype inntektsmeldingErketype;
-
-
     @BeforeEach
     public void setUp() {
         fordel = new Fordel();
@@ -30,10 +24,6 @@ public class FpsakTestBase extends TestScenarioTestBase {
         overstyrer = new Saksbehandler();
         beslutter = new Saksbehandler();
         klagebehandler = new Saksbehandler();
-
-//        foreldrepengeSøknadErketyper = new SøknadForeldrepengeErketyper();
-//        inntektsmeldingErketype = new InntektsmeldingErketype();
-
     }
 
     protected Kodeverk hentKodeverk() {

--- a/src/main/java/no/nav/foreldrepenger/autotest/base/TestBase.java
+++ b/src/main/java/no/nav/foreldrepenger/autotest/base/TestBase.java
@@ -4,14 +4,13 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.List;
 
-import no.nav.foreldrepenger.autotest.util.testscenario.TestscenarioRepositoryImpl;
 import org.junit.jupiter.api.BeforeAll;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.qameta.allure.Step;
 import no.nav.foreldrepenger.autotest.util.konfigurasjon.MiljoKonfigurasjon;
-import no.nav.foreldrepenger.vtp.felles.PropertiesUtils;
+import no.nav.foreldrepenger.autotest.util.testscenario.TestscenarioRepositoryImpl;
 
 public abstract class TestBase {
 
@@ -28,8 +27,6 @@ public abstract class TestBase {
      */
     @BeforeAll
     protected static void setUpAll() {
-        String propertiesDir = System.getProperty("application.root");
-        PropertiesUtils.initProperties(propertiesDir == null ? ".." : propertiesDir);
         MiljoKonfigurasjon.initProperties();
         testscenarioRepositoryImpl = new TestscenarioRepositoryImpl();
     }
@@ -37,15 +34,6 @@ public abstract class TestBase {
     /*
      * Verifisering
      */
-    protected void verifiserListeInneholder(List<Object> liste, Object object1) {
-        for (Object object2 : liste) {
-            if (object1.equals(object2)) {
-                return;
-            }
-        }
-        verifiser(false, "Listen: " + liste.toString() + " inneholdt ikke: " + object1.toString());
-    }
-
     protected void verifiserLikhet(Object verdiGjeldende, Object verdiForventet) {
         verifiserLikhet(verdiGjeldende, verdiForventet, "Object");
     }

--- a/src/test/java/no/nav/foreldrepenger/autotest/foreldrepenger/VerdikjedeForeldrepenger.java
+++ b/src/test/java/no/nav/foreldrepenger/autotest/foreldrepenger/VerdikjedeForeldrepenger.java
@@ -49,7 +49,6 @@ import no.nav.foreldrepenger.autotest.klienter.fpsak.behandlinger.dto.aksjonspun
 import no.nav.foreldrepenger.autotest.klienter.fpsak.behandlinger.dto.aksjonspunktbekreftelse.VurderBeregnetInntektsAvvikBekreftelse;
 import no.nav.foreldrepenger.autotest.klienter.fpsak.behandlinger.dto.aksjonspunktbekreftelse.VurderFaktaOmBeregningBekreftelse;
 import no.nav.foreldrepenger.autotest.klienter.fpsak.behandlinger.dto.aksjonspunktbekreftelse.VurderPerioderOpptjeningBekreftelse;
-import no.nav.foreldrepenger.autotest.klienter.fpsak.behandlinger.dto.aksjonspunktbekreftelse.VurderSoknadsfristForeldrepengerBekreftelse;
 import no.nav.foreldrepenger.autotest.klienter.fpsak.behandlinger.dto.aksjonspunktbekreftelse.VurderTilbakekrevingVedFeilutbetalingBekreftelse;
 import no.nav.foreldrepenger.autotest.klienter.fpsak.behandlinger.dto.aksjonspunktbekreftelse.VurderVarigEndringEllerNyoppstartetSNBekreftelse;
 import no.nav.foreldrepenger.autotest.klienter.fpsak.behandlinger.dto.aksjonspunktbekreftelse.VurderingAvKlageBekreftelse.VurderingAvKlageNfpBekreftelse;
@@ -287,11 +286,7 @@ public class VerdikjedeForeldrepenger extends ForeldrepengerTestBase {
 
         saksbehandler.erLoggetInnMedRolle(Aktoer.Rolle.SAKSBEHANDLER);
         saksbehandler.hentFagsak(saksnummerMor);
-        VurderSoknadsfristForeldrepengerBekreftelse vurderSoknadsfristForeldrepengerBekreftelse = saksbehandler.hentAksjonspunktbekreftelse(VurderSoknadsfristForeldrepengerBekreftelse.class);
-        vurderSoknadsfristForeldrepengerBekreftelse.bekreftHarGyldigGrunn(fpStartdatoMor);
-        saksbehandler.bekreftAksjonspunkt(vurderSoknadsfristForeldrepengerBekreftelse);
-
-        foreslårVedtakFatterVedtakOgVenterTilAvsluttetBehandling(saksnummerMor, false);
+        saksbehandler.ventTilAvsluttetBehandling();
 
         /*
          * FAR: Søker med to arbeidsforhold i samme virksomhet, orgn.nr, men med ulik arbeidsforholdID.
@@ -410,13 +405,7 @@ public class VerdikjedeForeldrepenger extends ForeldrepengerTestBase {
 
         saksbehandler.erLoggetInnMedRolle(Aktoer.Rolle.SAKSBEHANDLER);
         saksbehandler.hentFagsak(saksnummerMor);
-        VurderSoknadsfristForeldrepengerBekreftelse vurderSoknadsfristForeldrepengerBekreftelse = saksbehandler.hentAksjonspunktbekreftelse(VurderSoknadsfristForeldrepengerBekreftelse.class);
-        vurderSoknadsfristForeldrepengerBekreftelse
-                .bekreftHarGyldigGrunn(fpStartdatoMor)
-                .setBegrunnelse("Begrunnelse fra Autotest.");
-        saksbehandler.bekreftAksjonspunkt(vurderSoknadsfristForeldrepengerBekreftelse);
-
-        foreslårVedtakFatterVedtakOgVenterTilAvsluttetBehandling(saksnummerMor, false);
+        saksbehandler.ventTilAvsluttetBehandling();
 
         /*
          * FAR: Søker som FL. Har frilansinntekt frem til, men ikke inklusiv, skjæringstidspunktet.
@@ -717,7 +706,8 @@ public class VerdikjedeForeldrepenger extends ForeldrepengerTestBase {
         var søknadMor = lagSøknadForeldrepenger(
                 fødselsdato, aktørIdMor, SøkersRolle.MOR)
                 .medFordeling(fordelingMor)
-                .medRelasjonTilBarnet(RelasjonTilBarnetErketyper.fødsel(2, fødselsdato));
+                .medRelasjonTilBarnet(RelasjonTilBarnetErketyper.fødsel(2, fødselsdato))
+                .medMottattDato(fpStartdatoMor.minusWeeks(3));
         fordel.erLoggetInnMedRolle(Aktoer.Rolle.SAKSBEHANDLER);
         var saksnummerMor = fordel.sendInnSøknad(
                 søknadMor.build(),
@@ -740,12 +730,6 @@ public class VerdikjedeForeldrepenger extends ForeldrepengerTestBase {
 
         saksbehandler.erLoggetInnMedRolle(Aktoer.Rolle.SAKSBEHANDLER);
         saksbehandler.hentFagsak(saksnummerMor);
-        VurderSoknadsfristForeldrepengerBekreftelse vurderSoknadsfristForeldrepengerBekreftelse = saksbehandler.hentAksjonspunktbekreftelse(VurderSoknadsfristForeldrepengerBekreftelse.class);
-        vurderSoknadsfristForeldrepengerBekreftelse.bekreftHarGyldigGrunn(fpStartdatoMor);
-        saksbehandler.bekreftAksjonspunkt(vurderSoknadsfristForeldrepengerBekreftelse);
-
-        foreslårVedtakFatterVedtakOgVenterTilAvsluttetBehandling(saksnummerMor, false);
-
         Saldoer saldoerFørstgangsbehandling = saksbehandler.valgtBehandling.getSaldoer();
         verifiser(saldoerFørstgangsbehandling.getStonadskontoer().get(FORELDREPENGER_FØR_FØDSEL).getSaldo() == 0,
                 "Forventer at saldoen for stønadskonton FORELDREPENGER_FØR_FØDSEL er brukt opp!");
@@ -836,7 +820,6 @@ public class VerdikjedeForeldrepenger extends ForeldrepengerTestBase {
         saksbehandler.velgRevurderingBehandling();
         FastsettUttaksperioderManueltBekreftelse fastsettUttaksperioderManueltBekreftelse =
                 saksbehandler.hentAksjonspunktbekreftelse(FastsettUttaksperioderManueltBekreftelse.class);
-        fastsettUttaksperioderManueltBekreftelse.innvilgPeriode(fpStartdatoFar, fpStartdatoFar.plusWeeks(4).minusDays(1));
         fastsettUttaksperioderManueltBekreftelse.innvilgPeriode(
                 fpStartdatoFar,
                 fpStartdatoFar.plusWeeks(4).minusDays(1),
@@ -1045,7 +1028,8 @@ public class VerdikjedeForeldrepenger extends ForeldrepengerTestBase {
                 uttaksperiode(FELLESPERIODE, fellesperiodeStartFar, fellesperiodeSluttFar));
         var søknadFar = lagSøknadForeldrepengerAdopsjon(
                 omsorgsovertakelsedatoe, aktørIdFar, SøkersRolle.FAR, false)
-                .medFordeling(fordelingFar);
+                .medFordeling(fordelingFar)
+                .medMottattDato(fpStartdatoFar.minusWeeks(3));
         fordel.erLoggetInnMedRolle(Aktoer.Rolle.SAKSBEHANDLER);
         var saksnummerFar = fordel.sendInnSøknad(
                 søknadFar.build(),
@@ -1074,10 +1058,6 @@ public class VerdikjedeForeldrepenger extends ForeldrepengerTestBase {
                 saksbehandler.hentAksjonspunktbekreftelse(AvklarFaktaAdopsjonsdokumentasjonBekreftelse.class);
         avklarFaktaAdopsjonsdokumentasjonBekreftelseFar.setBegrunnelse("Adopsjon behandlet av Autotest.");
         saksbehandler.bekreftAksjonspunkt(avklarFaktaAdopsjonsdokumentasjonBekreftelseFar);
-
-        VurderSoknadsfristForeldrepengerBekreftelse vurderSoknadsfristForeldrepengerBekreftelse = saksbehandler.hentAksjonspunktbekreftelse(VurderSoknadsfristForeldrepengerBekreftelse.class);
-        vurderSoknadsfristForeldrepengerBekreftelse.bekreftHarGyldigGrunn(fpStartdatoFar);
-        saksbehandler.bekreftAksjonspunkt(vurderSoknadsfristForeldrepengerBekreftelse);
 
         FastsettUttaksperioderManueltBekreftelse fastsettUttaksperioderManueltBekreftelse =
                 saksbehandler.hentAksjonspunktbekreftelse(FastsettUttaksperioderManueltBekreftelse.class);
@@ -1332,7 +1312,6 @@ public class VerdikjedeForeldrepenger extends ForeldrepengerTestBase {
         var søknadMor = lagSøknadForeldrepengerFødsel(
                 fødselsdato, aktørIdMor, SøkersRolle.MOR)
                 .medFordeling(fordelingMor)
-                // TODO: Sjekk hvofor mottatdato ikke blir satt. Viser feil dato i frontend.
                 .medMottattDato(fpStartdatoMor.minusWeeks(4));
         fordel.erLoggetInnMedRolle(Aktoer.Rolle.SAKSBEHANDLER);
         var saksnummerMor = fordel.sendInnSøknad(


### PR DESCRIPTION
Nå fungere mottatDato i søknad og har fjernet unødvendige VurderSøknadsfrist AP i verdikjedetestene.

Ryddet bort instansiering av propertyfiler siden det ikke er i bruk.