### PR TITLE
NOJIRA scenario matcher ikke tester

### DIFF
--- a/src/main/resources/scenarios/78-MOR-1-barn-3-AF-stillingsprosent-100-100-100/personopplysning.json
+++ b/src/main/resources/scenarios/78-MOR-1-barn-3-AF-stillingsprosent-100-100-100/personopplysning.json
@@ -60,16 +60,6 @@
 	},
 	"familierelasjoner": [
 		{
-			"rolle": "BARN",
-			"til": {
-				"@type": "barn",
-				"ident": "${barn1}",
-				"fornavn": "${nevø1}",
-				"etternavn": "Duck",
-				"fødselsdato": "now()-P2W"
-			}
-		},
-		{
 			"rolle": "EKTE",
 			"til": {
 				"@type": "annenPart",

--- a/src/main/resources/scenarios/84-MOR-1-barn-5-mnd-2-AF-1-aktivt-over6G-og-FAR-2-AF-1-aktivt-over6G/personopplysning.json
+++ b/src/main/resources/scenarios/84-MOR-1-barn-5-mnd-2-AF-1-aktivt-over6G-og-FAR-2-AF-1-aktivt-over6G/personopplysning.json
@@ -66,7 +66,7 @@
 				"ident": "${barn1}",
 				"fornavn": "${nevø1}",
 				"etternavn": "Duck",
-				"fødselsdato": "now()-P5M"
+				"fødselsdato": "now()-P3Y"
 			}
 		},
 		{


### PR DESCRIPTION
SVP/78: Fødsel for to uker siden og termin om 3 mnd. Tilrettelegging fram i tid -> Skal avslås
FP/84: Mismatch mellom tester og barn
Skyldes at vi er flinkere til å inkludere barn fra scenarier (større slingringsmonn)