### PR TITLE
FIX: Rettelser for at tilbakekreving-autotester skal gå grønt

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <sha1/>
         <changelist>-SNAPSHOT</changelist>
 
-        <vtp.versjon>1.0.6</vtp.versjon>
+        <vtp.versjon>1.0.8</vtp.versjon>
         <dokumentgenerator.version>1.0-20200327105749-73dec14</dokumentgenerator.version>
         <aspectj.version>1.9.6</aspectj.version>
         <jackson.version>2.12.1</jackson.version>

--- a/src/main/java/no/nav/foreldrepenger/autotest/aktoerer/fptilbake/TilbakekrevingSaksbehandler.java
+++ b/src/main/java/no/nav/foreldrepenger/autotest/aktoerer/fptilbake/TilbakekrevingSaksbehandler.java
@@ -31,6 +31,7 @@ import no.nav.foreldrepenger.autotest.klienter.fptilbake.okonomi.dto.BeregningRe
 import no.nav.foreldrepenger.autotest.klienter.fptilbake.okonomi.dto.Kravgrunnlag;
 import no.nav.foreldrepenger.autotest.klienter.fptilbake.prosesstask.ProsesstaskJerseyKlient;
 import no.nav.foreldrepenger.autotest.klienter.fptilbake.prosesstask.dto.NewProsessTaskDto;
+import no.nav.foreldrepenger.autotest.klienter.vtp.tilbakekreving.VTPTilbakekrevingJerseyKlient;
 import no.nav.foreldrepenger.autotest.util.AllureHelper;
 import no.nav.foreldrepenger.autotest.util.vent.Vent;
 
@@ -43,12 +44,14 @@ public class TilbakekrevingSaksbehandler extends Aktoer {
     private final BehandlingerJerseyKlient behandlingerKlient;
     private final OkonomiJerseyKlient okonomiKlient;
     private final ProsesstaskJerseyKlient prosesstaskKlient;
+    private final VTPTilbakekrevingJerseyKlient vtpTilbakekrevingJerseyKlient;
 
     public TilbakekrevingSaksbehandler(Rolle rolle) {
         super(rolle);
         behandlingerKlient = new BehandlingerJerseyKlient(cookieRequestFilter);
         okonomiKlient = new OkonomiJerseyKlient(cookieRequestFilter);
         prosesstaskKlient = new ProsesstaskJerseyKlient(cookieRequestFilter);
+        vtpTilbakekrevingJerseyKlient = new VTPTilbakekrevingJerseyKlient();
     }
 
     // Behandlinger actions
@@ -106,10 +109,11 @@ public class TilbakekrevingSaksbehandler extends Aktoer {
     // Økonomi actions
     public void sendNyttKravgrunnlag(Long saksnummer, String ident, int fpsakBehandlingId, String ytelseType) {
         Kravgrunnlag kravgrunnlag = new Kravgrunnlag(saksnummer, ident, fpsakBehandlingId, ytelseType, "NY");
-        sendNyttKravgrunnlag(kravgrunnlag);
+        sendNyttKravgrunnlag(kravgrunnlag, saksnummer, fpsakBehandlingId);
     }
 
-    public void sendNyttKravgrunnlag(Kravgrunnlag kravgrunnlag) {
+    public void sendNyttKravgrunnlag(Kravgrunnlag kravgrunnlag, Long saksnummer, int fpsakBehandlingId) {
+        vtpTilbakekrevingJerseyKlient.oppdaterTilbakekrevingKonsistens(saksnummer, fpsakBehandlingId);
         okonomiKlient.putGrunnlag(kravgrunnlag, valgtBehandling.id);
     }
 

--- a/src/main/java/no/nav/foreldrepenger/autotest/klienter/fptilbake/okonomi/OkonomiJerseyKlient.java
+++ b/src/main/java/no/nav/foreldrepenger/autotest/klienter/fptilbake/okonomi/OkonomiJerseyKlient.java
@@ -13,7 +13,7 @@ import no.nav.foreldrepenger.autotest.klienter.fptilbake.okonomi.dto.Kravgrunnla
 
 public class OkonomiJerseyKlient extends FptilbakeJerseyKlient {
 
-    private static final String GRUNNLAG_URL = "/grunnlag?";
+    private static final String GRUNNLAG_URL = "/grunnlag";
     private static final String BEREGNING_RESULTAT_URL = "/beregning/resultat";
 
     public OkonomiJerseyKlient(ClientRequestFilter filter) {

--- a/src/main/java/no/nav/foreldrepenger/autotest/klienter/vtp/tilbakekreving/VTPTilbakekrevingJerseyKlient.java
+++ b/src/main/java/no/nav/foreldrepenger/autotest/klienter/vtp/tilbakekreving/VTPTilbakekrevingJerseyKlient.java
@@ -1,0 +1,30 @@
+package no.nav.foreldrepenger.autotest.klienter.vtp.tilbakekreving;
+
+import static javax.ws.rs.client.Entity.json;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.qameta.allure.Step;
+import no.nav.foreldrepenger.autotest.klienter.vtp.VTPJerseyKlient;
+import no.nav.foreldrepenger.vtp.kontrakter.TilbakekrevingKonsistensDto;
+
+public class VTPTilbakekrevingJerseyKlient extends VTPJerseyKlient {
+
+    private static final String TILBAKEKREVING_KONSISTENS = "/tilbakekreving/konsistens";
+    private static final Logger LOG = LoggerFactory.getLogger(VTPTilbakekrevingJerseyKlient.class);
+
+    public VTPTilbakekrevingJerseyKlient() {
+        super();
+    }
+
+    @Step("Oppdaterer VTPs tilbakekrevingsmock med siste saksnummer og behandling")
+    public void oppdaterTilbakekrevingKonsistens(Long saksnummer, int behandlingId) {
+        LOG.info("Oppdaterer VTPs tilbakekrevingsmock med saksnummer {} og behandling {} for konsistens", saksnummer, behandlingId);
+
+        client.target(base)
+                .path(TILBAKEKREVING_KONSISTENS)
+                .request()
+                .post(json(new TilbakekrevingKonsistensDto(""+saksnummer, ""+behandlingId)));
+    }
+}

--- a/src/test/java/no/nav/foreldrepenger/autotest/fptilbake/engangsstonad/TilbakekrevingES.java
+++ b/src/test/java/no/nav/foreldrepenger/autotest/fptilbake/engangsstonad/TilbakekrevingES.java
@@ -18,6 +18,7 @@ import no.nav.foreldrepenger.autotest.dokumentgenerator.foreldrepengesoknad.buil
 import no.nav.foreldrepenger.autotest.klienter.fpsak.behandlinger.dto.aksjonspunktbekreftelse.FatterVedtakBekreftelse;
 import no.nav.foreldrepenger.autotest.klienter.fpsak.behandlinger.dto.aksjonspunktbekreftelse.ForeslåVedtakBekreftelse;
 import no.nav.foreldrepenger.autotest.klienter.fpsak.behandlinger.dto.aksjonspunktbekreftelse.VurderEktefellesBarnBekreftelse;
+import no.nav.foreldrepenger.autotest.klienter.fpsak.behandlinger.dto.aksjonspunktbekreftelse.avklarfakta.AvklarBrukerBosattBekreftelse;
 import no.nav.foreldrepenger.autotest.klienter.fpsak.behandlinger.dto.aksjonspunktbekreftelse.avklarfakta.AvklarBrukerHarGyldigPeriodeBekreftelse;
 import no.nav.foreldrepenger.autotest.klienter.fpsak.behandlinger.dto.aksjonspunktbekreftelse.avklarfakta.AvklarFaktaAdopsjonsdokumentasjonBekreftelse;
 import no.nav.foreldrepenger.autotest.klienter.fpsak.behandlinger.dto.aksjonspunktbekreftelse.avklarfakta.AvklarFaktaVergeBekreftelse;
@@ -83,7 +84,7 @@ public class TilbakekrevingES extends FptilbakeTestBase {
         Kravgrunnlag kravgrunnlag = new Kravgrunnlag(saksnummer, testscenario.personopplysninger().søkerIdent(),
                 saksbehandler.valgtBehandling.id, ytelseType, "NY");
         kravgrunnlag.leggTilGeneriskPeriode(ytelseType);
-        tbksaksbehandler.sendNyttKravgrunnlag(kravgrunnlag);
+        tbksaksbehandler.sendNyttKravgrunnlag(kravgrunnlag, saksnummer, saksbehandler.valgtBehandling.id);
         tbksaksbehandler.ventTilBehandlingHarAktivtAksjonspunkt(7003);
 
         var vurderFakta = (ApFaktaFeilutbetaling) tbksaksbehandler.hentAksjonspunktbehandling(7003);
@@ -138,6 +139,9 @@ public class TilbakekrevingES extends FptilbakeTestBase {
                 saksbehandler.hentKodeverk().MedlemskapManuellVurderingType.getKode("MEDLEM"),
                 saksbehandler.valgtBehandling.getMedlem().getMedlemskapPerioder());
         saksbehandler.bekreftAksjonspunkt(avklarBrukerHarGyldigPeriodeBekreftelse);
+        var bosatt = saksbehandler.hentAksjonspunktbekreftelse(AvklarBrukerBosattBekreftelse.class);
+        bosatt.getBekreftedePerioder().forEach(p -> p.setBosattVurdering(true));
+        saksbehandler.bekreftAksjonspunkt(bosatt);
         saksbehandler.bekreftAksjonspunktMedDefaultVerdier(ForeslåVedtakBekreftelse.class);
 
         beslutter.hentFagsak(saksnummer);
@@ -154,7 +158,7 @@ public class TilbakekrevingES extends FptilbakeTestBase {
         Kravgrunnlag kravgrunnlag = new Kravgrunnlag(saksnummer, testscenario.personopplysninger().søkerIdent(),
                 saksbehandler.valgtBehandling.id, ytelseType, "NY");
         kravgrunnlag.leggTilGeneriskPeriode(ytelseType);
-        tbksaksbehandler.sendNyttKravgrunnlag(kravgrunnlag);
+        tbksaksbehandler.sendNyttKravgrunnlag(kravgrunnlag, saksnummer, saksbehandler.valgtBehandling.id);
         tbksaksbehandler.ventTilBehandlingHarAktivtAksjonspunkt(7003);
 
         tbksaksbehandler.fjernVerge();

--- a/src/test/java/no/nav/foreldrepenger/autotest/fptilbake/foreldrepenger/TilbakekrevingFP.java
+++ b/src/test/java/no/nav/foreldrepenger/autotest/fptilbake/foreldrepenger/TilbakekrevingFP.java
@@ -78,7 +78,7 @@ public class TilbakekrevingFP extends FptilbakeTestBase {
         Kravgrunnlag kravgrunnlag = new Kravgrunnlag(saksnummer, testscenario.personopplysninger().søkerIdent(),
                 saksbehandler.valgtBehandling.id, ytelseType, "NY");
         kravgrunnlag.leggTilGeneriskPeriode();
-        tbksaksbehandler.sendNyttKravgrunnlag(kravgrunnlag);
+        tbksaksbehandler.sendNyttKravgrunnlag(kravgrunnlag, saksnummer, saksbehandler.valgtBehandling.id);
         tbksaksbehandler.ventTilBehandlingHarAktivtAksjonspunkt(7003);
 
         var vurderFakta = (ApFaktaFeilutbetaling) tbksaksbehandler.hentAksjonspunktbehandling(7003);
@@ -134,7 +134,7 @@ public class TilbakekrevingFP extends FptilbakeTestBase {
                 .setBegrunnelse("Begrunnelse");
         saksbehandler.bekreftAksjonspunkt(vurderBeregnetInntektsAvvikBekreftelse);
 
-        saksbehandler.harAksjonspunkt("5084");
+        verifiser(saksbehandler.harAksjonspunkt("5084"), "Har ikke aksjonspunkt 5084");
         var vurderTilbakekrevingVedNegativSimulering = saksbehandler.hentAksjonspunktbekreftelse(VurderTilbakekrevingVedNegativSimulering.class);
         vurderTilbakekrevingVedNegativSimulering.setTilbakekrevingMedVarsel();
         saksbehandler.bekreftAksjonspunkt(vurderTilbakekrevingVedNegativSimulering);
@@ -149,7 +149,7 @@ public class TilbakekrevingFP extends FptilbakeTestBase {
         Kravgrunnlag kravgrunnlag = new Kravgrunnlag(saksnummer, testscenario.personopplysninger().søkerIdent(),
                 saksbehandler.valgtBehandling.id, ytelseType, "NY");
         kravgrunnlag.leggTilGeneriskPeriode();
-        tbksaksbehandler.sendNyttKravgrunnlag(kravgrunnlag);
+        tbksaksbehandler.sendNyttKravgrunnlag(kravgrunnlag, saksnummer, saksbehandler.valgtBehandling.id);
 
         tbksaksbehandler.registrerBrukerrespons(true);
         tbksaksbehandler.ventTilBehandlingHarAktivtAksjonspunkt(7003);
@@ -220,7 +220,7 @@ public class TilbakekrevingFP extends FptilbakeTestBase {
                 .setBegrunnelse("Begrunnelse");
         saksbehandler.bekreftAksjonspunkt(vurderBeregnetInntektsAvvikBekreftelse);
 
-        saksbehandler.harAksjonspunkt("5084");
+        verifiser(saksbehandler.harAksjonspunkt("5084"), "Har ikke aksjonspunkt 5084");
         var vurderTilbakekrevingVedNegativSimulering = saksbehandler.hentAksjonspunktbekreftelse(VurderTilbakekrevingVedNegativSimulering.class);
         vurderTilbakekrevingVedNegativSimulering.setTilbakekrevingUtenVarsel();
         saksbehandler.bekreftAksjonspunkt(vurderTilbakekrevingVedNegativSimulering);
@@ -236,7 +236,7 @@ public class TilbakekrevingFP extends FptilbakeTestBase {
         Kravgrunnlag kravgrunnlag = new Kravgrunnlag(saksnummer, testscenario.personopplysninger().søkerIdent(),
                 saksbehandler.valgtBehandling.id, ytelseType, "NY");
         kravgrunnlag.leggTilPeriodeMedSmåBeløp();
-        tbksaksbehandler.sendNyttKravgrunnlag(kravgrunnlag);
+        tbksaksbehandler.sendNyttKravgrunnlag(kravgrunnlag, saksnummer, saksbehandler.valgtBehandling.id);
 
         tbksaksbehandler.ventTilBehandlingHarAktivtAksjonspunkt(7003);
         tbksaksbehandler.startAutomatiskBehandlingBatch();

--- a/src/test/java/no/nav/foreldrepenger/autotest/fptilbake/foreldrepenger/TilbakekrevingRevurdering.java
+++ b/src/test/java/no/nav/foreldrepenger/autotest/fptilbake/foreldrepenger/TilbakekrevingRevurdering.java
@@ -12,8 +12,6 @@ import java.time.LocalDate;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import io.qameta.allure.Description;
 import no.nav.foreldrepenger.autotest.base.FptilbakeTestBase;
@@ -35,7 +33,6 @@ import no.nav.vedtak.felles.xml.soeknad.uttak.v3.Fordeling;
 @Tag("fptilbake")
 public class TilbakekrevingRevurdering extends FptilbakeTestBase {
 
-    private static final Logger logger = LoggerFactory.getLogger(TilbakekrevingRevurdering.class);
     private static final String ytelseType = "FP";
 
     @Test
@@ -78,7 +75,7 @@ public class TilbakekrevingRevurdering extends FptilbakeTestBase {
         Kravgrunnlag kravgrunnlag = new Kravgrunnlag(saksnummer, testscenario.personopplysninger().søkerIdent(),
                 saksbehandler.valgtBehandling.id, ytelseType, "NY");
         kravgrunnlag.leggTilGeneriskPeriode();
-        tbksaksbehandler.sendNyttKravgrunnlag(kravgrunnlag);
+        tbksaksbehandler.sendNyttKravgrunnlag(kravgrunnlag, saksnummer, saksbehandler.valgtBehandling.id);
         tbksaksbehandler.ventTilBehandlingHarAktivtAksjonspunkt(7003);
 
         var vurderFakta = (ApFaktaFeilutbetaling) tbksaksbehandler.hentAksjonspunktbehandling(7003);
@@ -107,6 +104,10 @@ public class TilbakekrevingRevurdering extends FptilbakeTestBase {
         tbksaksbehandler.opprettTilbakekrevingRevurdering(saksnummer, saksbehandler.valgtBehandling.uuid,
                 tbksaksbehandler.valgtBehandling.id, ytelseType, RevurderingArsak.RE_FORELDELSE);
         tbksaksbehandler.hentSisteBehandling(saksnummer);
+        tbksaksbehandler.ventTilBehandlingHarAktivtAksjonspunkt(7003);
+        vurderFakta = (ApFaktaFeilutbetaling) tbksaksbehandler.hentAksjonspunktbehandling(7003);
+        vurderFakta.addGeneriskVurdering(ytelseType);
+        tbksaksbehandler.behandleAksjonspunkt(vurderFakta);
         tbksaksbehandler.ventTilBehandlingHarAktivtAksjonspunkt(5003);
 
         // mangler resten av revurderingsbehandlingen med aksjonpunkt for foreldelse

--- a/src/test/java/no/nav/foreldrepenger/autotest/fptilbake/svangerskapspenger/TilbakekrevingSVP.java
+++ b/src/test/java/no/nav/foreldrepenger/autotest/fptilbake/svangerskapspenger/TilbakekrevingSVP.java
@@ -94,7 +94,7 @@ public class TilbakekrevingSVP extends FptilbakeTestBase {
         Kravgrunnlag kravgrunnlag = new Kravgrunnlag(saksnummer, testscenario.personopplysninger().søkerIdent(),
                 saksbehandler.valgtBehandling.id, ytelseType, "NY");
         kravgrunnlag.leggTilGeneriskPeriode();
-        tbksaksbehandler.sendNyttKravgrunnlag(kravgrunnlag);
+        tbksaksbehandler.sendNyttKravgrunnlag(kravgrunnlag, saksnummer, saksbehandler.valgtBehandling.id);
         tbksaksbehandler.ventTilBehandlingHarAktivtAksjonspunkt(7003);
 
         var vurderFakta = (ApFaktaFeilutbetaling) tbksaksbehandler.hentAksjonspunktbehandling(7003);


### PR DESCRIPTION
Tar i bruk tjeneste i VTP som gjør det mulig å melde inn siste saksnummer og behandlingId, slik at kravgrunnlaget som returneres fra mock er konsistent med de faktiske sakene. Rettet feil i OkonomiJerseyKlient som gjorde at kallene ikke traff tjenester. Lagt til bekreftelse av aksjonspunkt 5020 i TilbakekrevingES etter endring i Fpsak der aksjonspunktet nå utledes. Også lagt til vurdering av aksjonspunkt 7003 i TilbakekrevingRevurdering for at testen skal gå grønn.