### PR TITLE
Utsettelse- og perioderesultatårsaker fri utsettelse

### DIFF
--- a/src/main/java/no/nav/foreldrepenger/autotest/domain/foreldrepenger/InnvilgetÅrsak.java
+++ b/src/main/java/no/nav/foreldrepenger/autotest/domain/foreldrepenger/InnvilgetÅrsak.java
@@ -1,5 +1,7 @@
 package no.nav.foreldrepenger.autotest.domain.foreldrepenger;
 
+import static java.util.Set.of;
+
 import java.util.Arrays;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -32,6 +34,7 @@ public enum InnvilgetÅrsak implements PeriodeResultatÅrsak {
     OVERFØRING_ANNEN_PART_SYKDOM_SKADE("2021", "§14-12: Overføring oppfylt, annen part er helt avhengig av hjelp til å ta seg av barnet"),
     OVERFØRING_ANNEN_PART_INNLAGT("2022", "§14-12: Overføring oppfylt, annen part er innlagt i helseinstitusjon"),
     OVERFØRING_SØKER_HAR_ALENEOMSORG_FOR_BARNET("2023", "§14-15 første ledd: Overføring oppfylt, søker har aleneomsorg for barnet"),
+    UTSETTELSE_GYLDIG("2024", "§14-11 Gyldig utsettelse"),
     GRADERING_FELLESPERIODE_ELLER_FORELDREPENGER("2030", "§14-9, jf. §14-16: Gradering av fellesperiode/foreldrepenger"),
     GRADERING_KVOTE_ELLER_OVERFØRT_KVOTE("2031", "§14-12, jf. §14-16: Gradering av kvote/overført kvote"),
     GRADERING_ALENEOMSORG("2032", "§14-15, jf. §14-16: Gradering foreldrepenger ved aleneomsorg"),

--- a/src/main/java/no/nav/foreldrepenger/autotest/domain/foreldrepenger/SøknadUtsettelseÅrsak.java
+++ b/src/main/java/no/nav/foreldrepenger/autotest/domain/foreldrepenger/SøknadUtsettelseÅrsak.java
@@ -18,6 +18,7 @@ public enum SøknadUtsettelseÅrsak {
     INSTITUSJON_BARN("INSTITUSJONSOPPHOLD_BARNET"),
     HV_OVELSE("HV_OVELSE"),
     NAV_TILTAK("NAV_TILTAK"),
+    FRI("FRI"),
     UDEFINERT("-"),
     ;
 

--- a/src/main/java/no/nav/foreldrepenger/autotest/domain/foreldrepenger/UttakUtsettelseÅrsak.java
+++ b/src/main/java/no/nav/foreldrepenger/autotest/domain/foreldrepenger/UttakUtsettelseÅrsak.java
@@ -19,6 +19,7 @@ public enum UttakUtsettelseÅrsak {
     BARN_INNLAGT("BARN_INNLAGT"),
     HV_OVELSE("HV_OVELSE"),
     NAV_TILTAK("NAV_TILTAK"),
+    FRI("FRI"),
     UDEFINERT("-"),
     ;
 

--- a/src/main/java/no/nav/foreldrepenger/autotest/søknad/modell/foreldrepenger/fordeling/UtsettelsesÅrsak.java
+++ b/src/main/java/no/nav/foreldrepenger/autotest/søknad/modell/foreldrepenger/fordeling/UtsettelsesÅrsak.java
@@ -7,7 +7,8 @@ public enum UtsettelsesÅrsak {
     INSTITUSJONSOPPHOLD_SØKER,
     INSTITUSJONSOPPHOLD_BARNET,
     HV_OVELSE("periode.utsettelse.hv"),
-    NAV_TILTAK("periode.utsettelse.nav");
+    NAV_TILTAK("periode.utsettelse.nav"),
+    FRI;
 
     private final String key;
 


### PR DESCRIPTION
Antar at dette fjerner noen ResponseProcessing-ting fra Jackson ved getUttakResultatPerioder() som vi så da Anders kjørte testene lokalt.
Fodsel.morSøkerGraderingOgUtsettelseMedToArbeidsforhold_utenAvvikendeInntektsmeldinger:995
Revurdering.endringssøknadMedUtsettelse:247 Revurdering.utsettelser_og_gradering_fra_førstegangsbehandling_skal_ikke_gå_til_manuell_behandling_ved_endringssøknad:573