### PR TITLE
TFP-4942 Endret PermisjonUtenSluttdatoDto til PermisjonOgMangelDto fo…

### DIFF
--- a/src/main/java/no/nav/foreldrepenger/autotest/domain/foreldrepenger/AksjonspunktÅrsak.java
+++ b/src/main/java/no/nav/foreldrepenger/autotest/domain/foreldrepenger/AksjonspunktÅrsak.java
@@ -1,0 +1,9 @@
+package no.nav.foreldrepenger.autotest.domain.foreldrepenger;
+
+public enum AksjonspunktÅrsak {
+    PERMISJON,
+    MANGLENDE_INNTEKTSMELDING,
+    INNTEKTSMELDING_UTEN_ARBEIDSFORHOLD,
+    ENDRING_I_ARBEIDSFORHOLDS_ID,
+    PERMISJON_UTEN_SLUTTDATO
+}

--- a/src/main/java/no/nav/foreldrepenger/autotest/domain/foreldrepenger/PermisjonsbeskrivelseType.java
+++ b/src/main/java/no/nav/foreldrepenger/autotest/domain/foreldrepenger/PermisjonsbeskrivelseType.java
@@ -1,0 +1,33 @@
+package no.nav.foreldrepenger.autotest.domain.foreldrepenger;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
+public enum PermisjonsbeskrivelseType {
+    UDEFINERT("-"),
+    PERMISJON("PERMISJON"),
+    UTDANNINGSPERMISJON("UTDANNINGSPERMISJON"),
+    VELFERDSPERMISJON("VELFERDSPERMISJON"),
+    PERMISJON_MED_FORELDREPENGER("PERMISJON_MED_FORELDREPENGER"),
+    PERMITTERING("PERMITTERING"),
+    PERMISJON_VED_MILITÆRTJENESTE("PERMISJON_VED_MILITÆRTJENESTE");
+
+    public static final String KODEVERK = "PERMISJONSBESKRIVELSE_TYPE";
+
+    @JsonValue
+    private final String kode;
+
+
+    PermisjonsbeskrivelseType(String kode) {
+        this.kode = kode;
+    }
+
+    PermisjonsbeskrivelseType(String kode, String navn) {
+        this.kode = kode;
+    }
+
+    public String getKode() {
+        return kode;
+    }
+}

--- a/src/main/java/no/nav/foreldrepenger/autotest/klienter/fpsak/behandlinger/dto/behandling/arbeidInntektsmelding/ArbeidsforholdDto.java
+++ b/src/main/java/no/nav/foreldrepenger/autotest/klienter/fpsak/behandlinger/dto/behandling/arbeidInntektsmelding/ArbeidsforholdDto.java
@@ -14,5 +14,5 @@ public record ArbeidsforholdDto(String arbeidsgiverIdent,
                                 BigDecimal stillingsprosent,
                                 ArbeidInntektsmeldingAksjonspunktÅrsak årsak,
                                 ArbeidsforholdKomplettVurderingType saksbehandlersVurdering,
-                                PermisjonUtenSluttdatoDto permisjonUtenSluttdatoDto,
+                                PermisjonOgMangelDto permisjonOgMangelDto,
                                 String begrunnelse){}

--- a/src/main/java/no/nav/foreldrepenger/autotest/klienter/fpsak/behandlinger/dto/behandling/arbeidInntektsmelding/PermisjonOgMangelDto.java
+++ b/src/main/java/no/nav/foreldrepenger/autotest/klienter/fpsak/behandlinger/dto/behandling/arbeidInntektsmelding/PermisjonOgMangelDto.java
@@ -1,0 +1,14 @@
+package no.nav.foreldrepenger.autotest.klienter.fpsak.behandlinger.dto.behandling.arbeidInntektsmelding;
+
+import no.nav.foreldrepenger.autotest.domain.foreldrepenger.AksjonspunktÅrsak;
+import no.nav.foreldrepenger.autotest.domain.foreldrepenger.BekreftetPermisjonStatus;
+import no.nav.foreldrepenger.autotest.domain.foreldrepenger.PermisjonsbeskrivelseType;
+
+import java.time.LocalDate;
+
+public record PermisjonOgMangelDto(LocalDate permisjonFom,
+                                   LocalDate permisjonTom,
+                                   PermisjonsbeskrivelseType type,
+                                   AksjonspunktÅrsak årsak,
+                                   BekreftetPermisjonStatus permisjonStatus){}
+

--- a/src/main/java/no/nav/foreldrepenger/autotest/klienter/fpsak/behandlinger/dto/behandling/arbeidInntektsmelding/PermisjonUtenSluttdatoDto.java
+++ b/src/main/java/no/nav/foreldrepenger/autotest/klienter/fpsak/behandlinger/dto/behandling/arbeidInntektsmelding/PermisjonUtenSluttdatoDto.java
@@ -1,9 +1,0 @@
-package no.nav.foreldrepenger.autotest.klienter.fpsak.behandlinger.dto.behandling.arbeidInntektsmelding;
-
-import no.nav.foreldrepenger.autotest.domain.foreldrepenger.BekreftetPermisjonStatus;
-
-import java.time.LocalDate;
-
-public record PermisjonUtenSluttdatoDto(LocalDate permisjonFom,
-                                        BekreftetPermisjonStatus permisjonStatus){}
-


### PR DESCRIPTION
…r å få med alle permisjoner, og de permisjoner det aksjonspunkt om sluttdato på i samme dto. Alle permisjoner skal vises i Fakta om arbeid og inntekt.