### PR TITLE
Bedre generering av vedtakId, fjerne ubrukte felt i dto

### DIFF
--- a/src/main/java/no/nav/foreldrepenger/autotest/klienter/fpsak/behandlinger/dto/behandling/Soknad.java
+++ b/src/main/java/no/nav/foreldrepenger/autotest/klienter/fpsak/behandlinger/dto/behandling/Soknad.java
@@ -9,9 +9,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 public class Soknad {
     // Generelt
     protected LocalDate mottattDato;
-    protected String tilleggsopplysninger;
     protected String begrunnelseForSenInnsending;
-    protected String annenPartNavn;
 
     // Fødsel
     protected LocalDate utstedtdato;

--- a/src/main/java/no/nav/foreldrepenger/autotest/klienter/fptilbake/okonomi/dto/KravgrunnlagDetaljert.java
+++ b/src/main/java/no/nav/foreldrepenger/autotest/klienter/fptilbake/okonomi/dto/KravgrunnlagDetaljert.java
@@ -35,7 +35,7 @@ public class KravgrunnlagDetaljert {
 
     public KravgrunnlagDetaljert(Long saksnummer, String ident, String behandlingId, String ytelseType,
             String kravStatusKode) {
-        this.vedtakId = saksnummer - 11111;
+        this.vedtakId = Long.parseLong(behandlingId) - 11111;
         this.kravgrunnlagId = 10000L + (long) (Math.random() * (9999999L - 10000L));
         this.kravStatusKode = kravStatusKode;
         if (ytelseType.equals("ES")) {


### PR DESCRIPTION
Denne nye baselinen gjør at saksnummer begynner veldig lavt isf 152000000: create sequence SEQ_SAKSNUMMER  cache 100;