### PR TITLE
TFP-743 Endret svp autotest og verdikjedetest til å ikke involverer t…

### DIFF
--- a/src/main/java/no/nav/foreldrepenger/autotest/klienter/fpsak/behandlinger/dto/behandling/svangerskapspenger/Arbeidsforhold.java
+++ b/src/main/java/no/nav/foreldrepenger/autotest/klienter/fpsak/behandlinger/dto/behandling/svangerskapspenger/Arbeidsforhold.java
@@ -36,6 +36,12 @@ public class Arbeidsforhold {
         return eksternArbeidsforholdReferanse;
     }
 
+    public void setTilretteleggingBehovFom(LocalDate tilretteleggingBehovFom) {this.tilretteleggingBehovFom = tilretteleggingBehovFom;}
+
+    public void setTilretteleggingDatoer(List<Tilretteleggingsdato> tilretteleggingDatoer) {
+        this.tilretteleggingDatoer = tilretteleggingDatoer;
+    }
+
     public String getInternArbeidsforholdReferanse() {
         return internArbeidsforholdReferanse;
     }

--- a/src/main/java/no/nav/foreldrepenger/autotest/klienter/fpsak/behandlinger/dto/behandling/svangerskapspenger/Tilretteleggingsdato.java
+++ b/src/main/java/no/nav/foreldrepenger/autotest/klienter/fpsak/behandlinger/dto/behandling/svangerskapspenger/Tilretteleggingsdato.java
@@ -12,4 +12,9 @@ public class Tilretteleggingsdato {
     protected TilretteleggingType type;
     protected BigDecimal stillingsprosent;
 
+    public Tilretteleggingsdato(LocalDate fom, TilretteleggingType type, BigDecimal stillingsprosent) {
+        this.fom = fom;
+        this.type = type;
+        this.stillingsprosent = stillingsprosent;
+    }
 }

--- a/src/test/java/no/nav/foreldrepenger/autotest/fpsak/svangerskapspenger/Førstegangsbehandling.java
+++ b/src/test/java/no/nav/foreldrepenger/autotest/fpsak/svangerskapspenger/Førstegangsbehandling.java
@@ -11,6 +11,8 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import no.nav.foreldrepenger.autotest.klienter.fpsak.behandlinger.dto.aksjonspunktbekreftelse.ForeslåVedtakManueltBekreftelse;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -65,17 +67,8 @@ class Førstegangsbehandling extends FpsakTestBase {
         saksbehandler.hentFagsak(saksnummer);
         saksbehandler.bekreftAksjonspunktMedDefaultVerdier(AvklarFaktaFødselOgTilrettelegging.class);
         saksbehandler.bekreftAksjonspunktMedDefaultVerdier(BekreftSvangerskapspengervilkår.class);
-        saksbehandler.bekreftAksjonspunktMedDefaultVerdier(ForeslåVedtakBekreftelse.class);
-
-        beslutter.hentFagsak(saksnummer);
-
-        var bekreftelse = beslutter
-                .hentAksjonspunktbekreftelse(FatterVedtakBekreftelse.class)
-                .godkjennAksjonspunkter(beslutter.hentAksjonspunktSomSkalTilTotrinnsBehandling());
-        beslutter.fattVedtakOgVentTilAvsluttetBehandling(bekreftelse);
-        assertThat(beslutter.valgtBehandling.hentBehandlingsresultat())
-                .as("Behandlingsresultat")
-                .isEqualTo(BehandlingResultatType.INNVILGET);
+        saksbehandler.bekreftAksjonspunktMedDefaultVerdier(ForeslåVedtakManueltBekreftelse.class);
+        saksbehandler.ventTilAvsluttetBehandlingOgFagsakLøpendeEllerAvsluttet();
 
         var tilkjentYtelsePerioder = saksbehandler.valgtBehandling.getBeregningResultatForeldrepenger()
                 .getPerioder();
@@ -155,17 +148,8 @@ class Førstegangsbehandling extends FpsakTestBase {
         saksbehandler.hentFagsak(saksnummer);
         saksbehandler.bekreftAksjonspunktMedDefaultVerdier(AvklarFaktaFødselOgTilrettelegging.class);
         saksbehandler.bekreftAksjonspunktMedDefaultVerdier(BekreftSvangerskapspengervilkår.class);
-        saksbehandler.bekreftAksjonspunktMedDefaultVerdier(ForeslåVedtakBekreftelse.class);
-
-        beslutter.hentFagsak(saksnummer);
-
-        var bekreftelse = beslutter
-                .hentAksjonspunktbekreftelse(FatterVedtakBekreftelse.class)
-                .godkjennAksjonspunkter(beslutter.hentAksjonspunktSomSkalTilTotrinnsBehandling());
-        beslutter.fattVedtakOgVentTilAvsluttetBehandling(bekreftelse);
-        assertThat(beslutter.valgtBehandling.hentBehandlingsresultat())
-                .as("Behandlingsresultat")
-                .isEqualTo(BehandlingResultatType.INNVILGET);
+        saksbehandler.bekreftAksjonspunktMedDefaultVerdier(ForeslåVedtakManueltBekreftelse.class);
+        saksbehandler.ventTilAvsluttetBehandlingOgFagsakLøpendeEllerAvsluttet();
 
         // Verifisering av Beregning
         var bgPerioder = saksbehandler.valgtBehandling.getBeregningsgrunnlag()
@@ -224,14 +208,11 @@ class Førstegangsbehandling extends FpsakTestBase {
         saksbehandler.hentFagsak(saksnummerSVP);
         saksbehandler.bekreftAksjonspunktMedDefaultVerdier(AvklarFaktaFødselOgTilrettelegging.class);
         saksbehandler.bekreftAksjonspunktMedDefaultVerdier(BekreftSvangerskapspengervilkår.class);
-        saksbehandler.bekreftAksjonspunktMedDefaultVerdier(ForeslåVedtakBekreftelse.class);
+        saksbehandler.bekreftAksjonspunktMedDefaultVerdier(ForeslåVedtakManueltBekreftelse.class);
+        saksbehandler.ventTilAvsluttetBehandlingOgFagsakLøpendeEllerAvsluttet();
 
-        beslutter.hentFagsak(saksnummerSVP);
-        var bekreftelse = beslutter
-                .hentAksjonspunktbekreftelse(FatterVedtakBekreftelse.class)
-                .godkjennAksjonspunkter(beslutter.hentAksjonspunktSomSkalTilTotrinnsBehandling());
-        beslutter.fattVedtakOgVentTilAvsluttetBehandling(bekreftelse);
-        assertThat(beslutter.valgtBehandling.hentBehandlingsresultat())
+
+        assertThat(saksbehandler.valgtBehandling.hentBehandlingsresultat())
                 .as("Behandlingsresultat")
                 .isEqualTo(BehandlingResultatType.INNVILGET);
 
@@ -249,20 +230,16 @@ class Førstegangsbehandling extends FpsakTestBase {
         overstyrer.ventPåOgVelgRevurderingBehandling();
         overstyrer.bekreftAksjonspunktMedDefaultVerdier(AvklarFaktaFødselOgTilrettelegging.class);
         overstyrer.bekreftAksjonspunktMedDefaultVerdier(BekreftSvangerskapspengervilkår.class);
-        overstyrer.bekreftAksjonspunktMedDefaultVerdier(ForeslåVedtakBekreftelse.class);
+        overstyrer.bekreftAksjonspunktMedDefaultVerdier(ForeslåVedtakManueltBekreftelse.class);
+        overstyrer.ventTilAvsluttetBehandlingOgFagsakLøpendeEllerAvsluttet();
 
-        beslutter.hentFagsak(saksnummerSVP);
+        saksbehandler.hentFagsak(saksnummerSVP);
 
-        var bekreftelse2 = beslutter
-                .hentAksjonspunktbekreftelse(FatterVedtakBekreftelse.class)
-                .godkjennAksjonspunkter(beslutter.hentAksjonspunktSomSkalTilTotrinnsBehandling());
-        beslutter.fattVedtakOgVentTilAvsluttetBehandling(bekreftelse2);
-
-        assertThat(beslutter.valgtBehandling.getBehandlingÅrsaker())
+        assertThat(saksbehandler.valgtBehandling.getBehandlingÅrsaker())
                 .map(BehandlingÅrsak::behandlingArsakType)
                 .containsExactly(BehandlingÅrsakType.OPPHØR_YTELSE_NYTT_BARN);
-        assertThat(beslutter.valgtBehandling.hentBehandlingsresultat()).isEqualTo(BehandlingResultatType.OPPHØR);
-        var tilkjentYtelsePerioder = beslutter.valgtBehandling.getBeregningResultatForeldrepenger()
+        assertThat(saksbehandler.valgtBehandling.hentBehandlingsresultat()).isEqualTo(BehandlingResultatType.OPPHØR);
+        var tilkjentYtelsePerioder = saksbehandler.valgtBehandling.getBeregningResultatForeldrepenger()
                 .getPerioder();
         assertThat(tilkjentYtelsePerioder)
                 .as("Antall tilkjent ytelses peridoer")
@@ -274,7 +251,5 @@ class Førstegangsbehandling extends FpsakTestBase {
         assertThat(tilkjentYtelsePerioder.get(1).getDagsats())
                 .as("Avslått tilkjent ytelse med dagsats 0")
                 .isZero();
-
-
     }
 }

--- a/src/test/java/no/nav/foreldrepenger/autotest/verdikjedetester/VerdikjedeSvangerskapspenger.java
+++ b/src/test/java/no/nav/foreldrepenger/autotest/verdikjedetester/VerdikjedeSvangerskapspenger.java
@@ -6,6 +6,13 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
 
+import no.nav.foreldrepenger.autotest.klienter.fpsak.behandlinger.dto.aksjonspunktbekreftelse.FatterVedtakBekreftelse;
+
+import no.nav.foreldrepenger.autotest.klienter.fpsak.behandlinger.dto.aksjonspunktbekreftelse.ForeslåVedtakManueltBekreftelse;
+
+import no.nav.foreldrepenger.autotest.klienter.fpsak.behandlinger.dto.behandling.svangerskapspenger.TilretteleggingType;
+import no.nav.foreldrepenger.autotest.klienter.fpsak.behandlinger.dto.behandling.svangerskapspenger.Tilretteleggingsdato;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -63,8 +70,9 @@ class VerdikjedeSvangerskapspenger extends VerdikjedeTestBase {
                 .godkjenn()
                 .setBegrunnelse("Godkjenner vilkår");
         saksbehandler.bekreftAksjonspunkt(bekreftSvangerskapspengervilkår);
+        saksbehandler.bekreftAksjonspunktMedDefaultVerdier(ForeslåVedtakManueltBekreftelse.class);
+        saksbehandler.ventTilAvsluttetBehandlingOgFagsakLøpendeEllerAvsluttet();
 
-        foreslårOgFatterVedtakVenterTilAvsluttetBehandlingOgSjekkerOmBrevErSendt(saksnummer, false);
         assertThat(saksbehandler.valgtBehandling.hentBehandlingsresultat())
                 .as("Behandlingsresultat")
                 .isEqualTo(BehandlingResultatType.INNVILGET);
@@ -114,8 +122,9 @@ class VerdikjedeSvangerskapspenger extends VerdikjedeTestBase {
                 .godkjenn()
                 .setBegrunnelse("Godkjenner vilkår");
         saksbehandler.bekreftAksjonspunkt(bekreftSvangerskapspengervilkår);
+        saksbehandler.bekreftAksjonspunktMedDefaultVerdier(ForeslåVedtakManueltBekreftelse.class);
+        saksbehandler.ventTilAvsluttetBehandlingOgFagsakLøpendeEllerAvsluttet();
 
-        foreslårOgFatterVedtakVenterTilAvsluttetBehandlingOgSjekkerOmBrevErSendt(saksnummer, false);
         assertThat(saksbehandler.valgtBehandling.hentBehandlingsresultat())
                 .as("Behandlingsresultat")
                 .isEqualTo(BehandlingResultatType.INNVILGET);
@@ -167,7 +176,8 @@ class VerdikjedeSvangerskapspenger extends VerdikjedeTestBase {
                 .setBegrunnelse("Godkjenner vilkår");
         saksbehandler.bekreftAksjonspunkt(bekreftSvangerskapspengervilkår);
 
-        foreslårOgFatterVedtakVenterTilAvsluttetBehandlingOgSjekkerOmBrevErSendt(saksnummer, false);
+        foreslårOgFatterVedtakVenterTilAvsluttetBehandlingOgSjekkerOmBrevErSendt(saksnummer, true);
+
         assertThat(saksbehandler.valgtBehandling.hentBehandlingsresultat())
                 .as("Behandlingsresultat")
                 .isEqualTo(BehandlingResultatType.INNVILGET);
@@ -234,7 +244,9 @@ class VerdikjedeSvangerskapspenger extends VerdikjedeTestBase {
                 .setBegrunnelse("Godkjenner vilkår");
         saksbehandler.bekreftAksjonspunkt(bekreftSvangerskapspengervilkår);
 
-        foreslårOgFatterVedtakVenterTilAvsluttetBehandlingOgSjekkerOmBrevErSendt(saksnummer1, false);
+        saksbehandler.bekreftAksjonspunktMedDefaultVerdier(ForeslåVedtakManueltBekreftelse.class);
+        saksbehandler.ventTilAvsluttetBehandlingOgFagsakLøpendeEllerAvsluttet();
+
         assertThat(saksbehandler.valgtBehandling.hentBehandlingsresultat())
                 .as("Behandlingsresultat")
                 .isEqualTo(BehandlingResultatType.INNVILGET);
@@ -265,6 +277,9 @@ class VerdikjedeSvangerskapspenger extends VerdikjedeTestBase {
         var avklarFaktaFødselOgTilrettelegging2 = saksbehandler
                 .hentAksjonspunktbekreftelse(AvklarFaktaFødselOgTilrettelegging.class);
         avklarFaktaFødselOgTilrettelegging2.setBegrunnelse("Begrunnelse");
+        avklarFaktaFødselOgTilrettelegging2.getBekreftetSvpArbeidsforholdList().get(0).setTilretteleggingBehovFom(LocalDate.now().minusDays(7));
+        avklarFaktaFødselOgTilrettelegging2.getBekreftetSvpArbeidsforholdList().get(0).setTilretteleggingDatoer(
+                List.of(new Tilretteleggingsdato(LocalDate.now().minusDays(7), TilretteleggingType.INGEN_TILRETTELEGGING, BigDecimal.valueOf(100))));
         saksbehandler.bekreftAksjonspunkt(avklarFaktaFødselOgTilrettelegging2);
 
         var bekreftSvangerskapspengervilkår2 = saksbehandler
@@ -357,7 +372,9 @@ class VerdikjedeSvangerskapspenger extends VerdikjedeTestBase {
                 .setBegrunnelse("Godkjenner vilkår");
         saksbehandler.bekreftAksjonspunkt(bekreftSvangerskapspengervilkår);
 
-        foreslårOgFatterVedtakVenterTilAvsluttetBehandlingOgSjekkerOmBrevErSendt(saksnummer, false);
+        saksbehandler.bekreftAksjonspunktMedDefaultVerdier(ForeslåVedtakManueltBekreftelse.class);
+        saksbehandler.ventTilAvsluttetBehandlingOgFagsakLøpendeEllerAvsluttet();
+
         assertThat(saksbehandler.valgtBehandling.hentBehandlingsresultat())
                 .as("Behandlingsresultat")
                 .isEqualTo(BehandlingResultatType.INNVILGET);


### PR DESCRIPTION
…otrinn dersom svpvilkår er oppfylt og ingen endring i tilrettelegginger. Det opprettets ap Forslå vedtak manuelt i stedet. Ved endring vil totrinn opprettholdes.