### PR TITLE
Skisse til forenklet azure-oppsett

### DIFF
--- a/resources/pipeline/authserver/konfig.json
+++ b/resources/pipeline/authserver/konfig.json
@@ -45,142 +45,71 @@
                 },
                 {
                     "requestParam": "scope",
-                    "match": "api://vtp.teamforeldrepenger.fpsak/.default",
-                    "claims": {
-                        "aud": ["fpsak"]
-                    }
-                },
-                {
-                    "requestParam": "scope",
                     "match": "api://vtp.teamforeldrepenger.fpsak/swagger",
                     "claims": {
-                        "aud": ["fpsak"]
-                    }
-                },
-                {
-                    "requestParam": "scope",
-                    "match": "api://vtp.teamforeldrepenger.fptilbake/.default",
-                    "claims": {
-                        "aud": ["fptilbake"]
+                        "aud": ["vtp"]
                     }
                 },
                 {
                     "requestParam": "scope",
                     "match": "api://vtp.teamforeldrepenger.fptilbake/swagger",
                     "claims": {
-                        "aud": ["fptilbake"]
-                    }
-                },
-                {
-                    "requestParam": "scope",
-                    "match": "api://vtp.teamforeldrepenger.fpoppdrag/.default",
-                    "claims": {
-                        "aud": ["fpoppdrag"]
+                        "aud": ["vtp"]
                     }
                 },
                 {
                     "requestParam": "scope",
                     "match": "api://vtp.teamforeldrepenger.fpoppdrag/swagger",
                     "claims": {
-                        "aud": ["fpoppdrag"]
+                        "aud": ["vtp"]
                     }
                 },
-                {
-                    "requestParam": "scope",
-                    "match": "api://vtp.teamforeldrepenger.fpformidling/.default",
-                    "claims": {
-                        "aud": ["fpformidling"]
-                    }
-                },
-                {
                     "requestParam": "scope",
                     "match": "api://vtp.teamforeldrepenger.fpformidling/swagger",
                     "claims": {
-                        "aud": ["fpformidling"]
-                    }
-                },
-                {
-                    "requestParam": "scope",
-                    "match": "api://vtp.teamforeldrepenger.fpinfo/.default",
-                    "claims": {
-                        "aud": ["fpinfo"]
+                        "aud": ["vtp"]
                     }
                 },
                 {
                     "requestParam": "scope",
                     "match": "api://vtp.teamforeldrepenger.fpinfo/swagger",
                     "claims": {
-                        "aud": ["fpinfo"]
-                    }
-                },
-                {
-                    "requestParam": "scope",
-                    "match": "api://vtp.teamforeldrepenger.fpfordel/.default",
-                    "claims": {
-                        "aud": ["fpfordel"]
+                        "aud": ["vtp"]
                     }
                 },
                 {
                     "requestParam": "scope",
                     "match": "api://vtp.teamforeldrepenger.fpfordel/swagger",
                     "claims": {
-                        "aud": ["fpfordel"]
-                    }
-                },
-                {
-                    "requestParam": "scope",
-                    "match": "api://vtp.teamforeldrepenger.fpabonnent/.default",
-                    "claims": {
-                        "aud": ["fpabonnent"]
+                        "aud": ["vtp"]
                     }
                 },
                 {
                     "requestParam": "scope",
                     "match": "api://vtp.teamforeldrepenger.fpabonnent/swagger",
                     "claims": {
-                        "aud": ["fpabonnent"]
-                    }
-                },
-                {
-                    "requestParam": "scope",
-                    "match": "api://vtp.teamforeldrepenger.fprisk/.default",
-                    "claims": {
-                        "aud": ["fprisk"]
+                        "aud": ["vtp"]
                     }
                 },
                 {
                     "requestParam": "scope",
                     "match": "api://vtp.teamforeldrepenger.fprisk/swagger",
                     "claims": {
-                        "aud": ["fprisk"]
-                    }
-                },
-                {
-                    "requestParam": "scope",
-                    "match": "api://vtp.teamforeldrepenger.fplos/.default",
-                    "claims": {
-                        "aud": ["fplos"]
+                        "aud": ["vtp"]
                     }
                 },
                 {
                     "requestParam": "scope",
                     "match": "api://vtp.teamforeldrepenger.fplos/swagger",
                     "claims": {
-                        "aud": ["fplos"]
-                    }
-                },
-                {
-                    "requestParam": "scope",
-                    "match": "api://vtp.teamforeldrepenger.fpabakus/.default",
-                    "claims": {
-                        "aud": ["fpabakus"]
+                        "aud": ["vtp"]
                     }
                 },
                 {
                     "requestParam": "scope",
                     "match": "api://vtp.teamforeldrepenger.fpabakus/swagger",
                     "claims": {
-                        "aud": ["fpabakus"]
+                        "aud": ["vtp"]
                     }
                 },
                 {
@@ -188,63 +117,18 @@
                     "match": "client_credentials",
                     "claims": {
                         "sub": "system",
-                        "oid": "system"
+                        "oid": "system",
+                        "aud": ["vtp"],
+                        "azp_name": "vtp:teamforeldrepenger:vtp"
                     }
                 },
                 {
-                    "requestParam": "client_id",
-                    "match": "fpabakus",
+                    "requestParam": "grant_type",
+                    "match": "urn:ietf:params:oauth:grant-type:jwt-bearer",
                     "claims": {
-                        "azp_name": "vtp:teamforeldrepenger:fpabakus"
-                    }
-                },
-                {
-                    "requestParam": "client_id",
-                    "match": "fpabonnent",
-                    "claims": {
-                        "azp_name": "vtp:teamforeldrepenger:fpabonnent"
-                    }
-                },
-                {
-                    "requestParam": "client_id",
-                    "match": "fpfordel",
-                    "claims": {
-                        "azp_name": "vtp:teamforeldrepenger:fpfordel"
-                    }
-                },
-                {
-                    "requestParam": "client_id",
-                    "match": "fpformidling",
-                    "claims": {
-                        "azp_name": "vtp:teamforeldrepenger:fpformidling"
-                    }
-                },
-                {
-                    "requestParam": "client_id",
-                    "match": "fpoppdrag",
-                    "claims": {
-                        "azp_name": "vtp:teamforeldrepenger:fpoppdrag"
-                    }
-                },
-                {
-                    "requestParam": "client_id",
-                    "match": "fptilbake",
-                    "claims": {
-                        "azp_name": "vtp:teamforeldrepenger:fptilbake"
-                    }
-                },
-                {
-                    "requestParam": "client_id",
-                    "match": "fprisk",
-                    "claims": {
-                        "azp_name": "vtp:teamforeldrepenger:fprisk"
-                    }
-                },
-                {
-                    "requestParam": "client_id",
-                    "match": "fplos",
-                    "claims": {
-                        "azp_name": "vtp:teamforeldrepenger:fplos"
+                        "sub": "obo",
+                        "aud": ["vtp"],
+                        "azp_name": "vtp:teamforeldrepenger:vtp"
                     }
                 }
             ]

--- a/resources/pipeline/common.env
+++ b/resources/pipeline/common.env
@@ -90,6 +90,9 @@ PIP_USERS=im-just-a-fake-code,vtp,srvfpoppdrag,srvfplos,srvfptilbake,srvfpformid
 # OIDC_STS
 OIDC_STS_WELL_KNOWN_URL=http://vtp:8060/rest/v1/sts/.well-known/openid-configuration
 #AzureAD
+AZURE_APP_CLIENT_ID=vtp
+AZURE_APP_CLIENT_SECRET=vtp
+
 AZURE_APP_WELL_KNOWN_URL=http://authserver:8086/azureAd/.well-known/openid-configuration
 AZURE_APP_JWK="
     {
@@ -128,32 +131,8 @@ AZURE_APP_JWKS="
 AZURE_APP_PRE_AUTHORIZED_APPS="
 [
   {
-    \"name\": \"vtp:teamforeldrepenger:fpsak\",
+    \"name\": \"vtp:teamforeldrepenger:vtp\",
     \"clientId\": \"381ce452-1d49-49df-9e7e-990ef0328d6c\"
-  },
-  {
-    \"name\": \"vtp:teamforeldrepenger:fplos\",
-    \"clientId\": \"381ce452-1d49-49df-9e7e-990ef0328d6c\"
-  },
-  {
-    \"name\": \"vtp:teamforeldrepenger:fpformidling\",
-    \"clientId\": \"381ce452-1d49-49df-9e7e-990ef0328d6c\"
-  },
-  {
-    \"name\": \"vtp:teamforeldrepenger:fptilbake\",
-    \"clientId\": \"381ce452-1d49-49df-9e7e-990ef0328d6c\"
-  },
-  {
-    \"name\": \"vtp:teamforeldrepenger:fpfordel\",
-    \"clientId\": \"381ce452-1d49-49df-9e7e-990ef0328d6c\"
-  },
-  {
-    \"name\": \"vtp:teamforeldrepenger:fpabonnent\",
-    \"clientId\": \"381ce452-1d49-49df-9e7e-990ef0328d6c\"
-  },
-  {
-    \"name\": \"vtp:teamforeldrepenger:fpabakus\",
-    \"clientId\": \"048eb0e8-e18a-473a-a87d-dfede7c65d84\"
   }
 ]"
 

--- a/resources/pipeline/compose.yml
+++ b/resources/pipeline/compose.yml
@@ -103,8 +103,6 @@ services:
     image: $FPABAKUS_IMAGE
     container_name: fpabakus
     mem_limit: 512mb
-    environment:
-      AZURE_APP_CLIENT_ID: fpabakus
     env_file:
       - *common-properties
       - fpabakus_datasource.env
@@ -131,7 +129,6 @@ services:
     mem_limit: 1gb
     shm_size: 256mb
     environment:
-      AZURE_APP_CLIENT_ID: fpsak
       ABAKUS_CALLBACK_URL: http://fpsak:8080/fpsak/api/registerdata/iay/callback
       FPOPPDRAG_OVERRIDE_PROXY_URL: http://localhost:9000/fpoppdrag/api
       UFORE_RS_URL: http://vtp:8060/rest/api/pesys/ufo
@@ -251,7 +248,6 @@ services:
     container_name: fpfordel
     mem_limit: 512mb
     environment:
-      AZURE_APP_CLIENT_ID: fpfordel
       KAFKA_TOPIC_JOURNAL_HENDELSE: teamdokumenthandtering.aapen-dok-journalfoering-vtp
       DOKARKIV_BASE_URL: http://vtp:8060/rest/dokarkiv/rest/journalpostapi/v1/journalpost
       FPFORDEL_IT_FP_URL: http://vtp:8060/rest/infotrygd/saker/foreldrepenger
@@ -282,7 +278,6 @@ services:
     container_name: fpformidling
     mem_limit: 512mb
     environment:
-      AZURE_APP_CLIENT_ID: fpformidling
       DOKGEN_REST_BASE_URL: http://fpdokgen:8080
       DOKDIST_REST_BASE_URL: http://vtp:8060/rest/dokdist/v1
       JOURNALPOST_REST_V1_URL: http://vtp:8060/rest/dokarkiv/rest/journalpostapi/v1/journalpost
@@ -330,7 +325,6 @@ services:
       - *common-properties
       - fpoppdrag_datasource.env
     environment:
-      AZURE_APP_CLIENT_ID: fpoppdrag
       OPPDRAG_SERVICE_URL: https://vtp:8063/soap/cics/services/oppdragService
     volumes:
       - *sertifikat-volum
@@ -352,7 +346,6 @@ services:
     mem_limit: 768mb
     shm_size: 256mb
     environment:
-      AZURE_APP_CLIENT_ID: fptilbake
       CONTEXT_PATH: /fptilbake
       DOKARKIV_BASE_URL: http://vtp:8060/rest/dokarkiv/rest/journalpostapi/v1/journalpost
       KAFKA_TILBAKEKREVING_BRUKERDIALOG_HENDELSE_V1_TOPIC_URL: teamforeldrepenger.tilbakekreving-brukerdialog-v1
@@ -387,7 +380,6 @@ services:
     container_name: fprisk
     mem_limit: 512mb
     environment:
-      AZURE_APP_CLIENT_ID: fprisk
       BRREG_PROXY: http://vtp:8060/rest/brreg/proxy/not/implemented
     env_file:
       - fprisk_datasource.env
@@ -414,7 +406,6 @@ services:
       - *common-properties
       - fpabonnent_datasource.env
     environment:
-      AZURE_APP_CLIENT_ID: fpabonnent
       KAFKA_PDL_LEESAH_TOPIC: pdl.leesah-v1
       KAFKA_PDL_LEESAH_APPLICATION_ID: fpabonnent-vtp
       KAFKA_AVRO_SERDE_CLASS: no.nav.foreldrepenger.abonnent.pdl.kafka.test.VtpKafkaAvroSerde
@@ -437,7 +428,6 @@ services:
     container_name: fplos
     mem_limit: 512mb
     environment:
-      AZURE_APP_CLIENT_ID: fplos
       AXSYS_URL: http://vtp:8060/rest/axsys-enhetstilgang
     env_file:
       - *common-properties
@@ -461,8 +451,6 @@ services:
     image: $FPINFO_IMAGE
     container_name: fpinfo
     mem_limit: 256mb
-    environment:
-      AZURE_APP_CLIENT_ID: fpinfo
     env_file:
       - *common-properties
       - fpinfo_datasource.env


### PR DESCRIPTION
En mulig forenkling av oppsett for AAD-authserver. Aud-validering går på at target sjekker at token.aud = env.clientId
Må kanskje ta med flere apps i compose + evt kanskje legge til regler for refresh_token + authorization_code
Ikke testet lokalt