### PR TITLE
Ignorer søknad-api i loggtester

### DIFF
--- a/src/test/java/no/nav/foreldrepenger/autotest/teknisk/logg/LoggTest.java
+++ b/src/test/java/no/nav/foreldrepenger/autotest/teknisk/logg/LoggTest.java
@@ -64,7 +64,7 @@ class LoggTest {
     );
 
     private static final List<String> ignoreContainersFeil = List.of("vtp", "audit.nais", "postgres", "oracle", "authserver");
-    private static final List<String> ignoreContainersSensitiveInfo = List.of("vtp", "audit.nais", "postgres", "oracle", "authserver", "fpsoknad-mottak");
+    private static final List<String> ignoreContainersSensitiveInfo = List.of("vtp", "audit.nais", "postgres", "oracle", "authserver", "fpsoknad-mottak", "foreldrepengesoknad-api");
     private static String IKKE_SJEKK_LENGDE_AV_CONTAINERE;
 
     private static String toNumericPattern(String s) {


### PR DESCRIPTION
For å få ut en bugfix i fordel. Bør vel re-enable api og mottak når vi har Innsending-kjede V2 på plass 