### PR TITLE
Fjerner sjekk på at det ikke er opprettet revurdering på barn2 fordi …

### DIFF
--- a/src/test/java/no/nav/foreldrepenger/autotest/fpsak/foreldrepenger/ToTetteOgMinsterettTester.java
+++ b/src/test/java/no/nav/foreldrepenger/autotest/fpsak/foreldrepenger/ToTetteOgMinsterettTester.java
@@ -325,9 +325,6 @@ class ToTetteOgMinsterettTester extends FpsakTestBase {
                 .as("Siste periode avslått med årsak ny stønadsperiode")
                 .isEqualTo(PeriodeResultatÅrsak.STØNADSPERIODE_NYTT_BARN);
 
-        // Verifiser at fagsak på barn 12 IKKE blir berørt og det IKKE opprettes en revurdering
-        saksbehandler.hentFagsak(saksnummerMorBarn2);
-        assertThat(saksbehandler.harRevurderingBehandling()).isFalse();
     }
 
     private UttakResultatPeriode sisteUttaksperiode() {


### PR DESCRIPTION
…vi har åpnet for sjekk av overlapp også på revurderinger, og da blir det opprettet en revurdering for å sjekke overlapp. Gitt at det er så få tilfeller anser vi det som ok i disse tilfellene.