### PR TITLE
Fix: Lar fptilgang bruke den lokale redisen.

### DIFF
--- a/resources/pipeline/compose.yml
+++ b/resources/pipeline/compose.yml
@@ -103,6 +103,9 @@ services:
       GRUPPE_OID_SKJERMET: 63b3f84f-1ec5-444b-ad33-2ad2d3495da1
       GRUPPE_OID_STRENGTFORTROLIG: df650e66-9590-4c96-8ecb-8efea46f1306
       GRUPPE_OID_FORTROLIG: bc7fde53-c4c3-4fff-9079-c6440ca5ff5e
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
+      REDIS_PASSWORD:
       APP_NAME: fptilgang
       NAIS_APP_NAME: fptilgang
     env_file:

--- a/resources/pipeline/compose.yml
+++ b/resources/pipeline/compose.yml
@@ -122,6 +122,8 @@ services:
     depends_on:
       audit.nais:
         condition: service_started
+      redis:
+        condition: service_started
       vtp:
         condition: service_healthy
   fpabakus:


### PR DESCRIPTION
Det vil kanskje ikke gi store fordeler lokalt, siden vi uansett kun kjører én pod (og lokal cache fungerer fint), men hovedformålet er å verifisere at alt fungerer som forventet også mot en faktisk Redis-instans.

This pull request includes an update to the `resources/pipeline/compose.yml` file to add new environment variables related to Redis configuration.

Configuration updates:

* [`resources/pipeline/compose.yml`](diffhunk://#diff-793a1bba7a7fa09a4a558cecc679b9090d1e7e66a5b518582babaacafe12d3e7R106-R108): Added `REDIS_HOST`, `REDIS_PORT`, and `REDIS_PASSWORD` environment variables to the `services` section. 