### PR TITLE
Trenger ikke vente på aksjonspunkt i test

### DIFF
--- a/src/test/java/no/nav/foreldrepenger/autotest/fpsak/foreldrepenger/Termin.java
+++ b/src/test/java/no/nav/foreldrepenger/autotest/fpsak/foreldrepenger/Termin.java
@@ -119,8 +119,6 @@ class Termin extends FpsakTestBase {
         // Løs 5085, ikke vent på inntektsmeldinger
         saksbehandler.fortsettUteninntektsmeldinger();
 
-        saksbehandler.hentAksjonspunkt(AksjonspunktKoder.VURDER_FAKTA_FOR_ATFL_SN);
-
         var arbeidsgiver = mor.arbeidsgiver();
         arbeidsgiver.sendInntektsmeldingerFP(saksnummer, startDatoForeldrepenger);
         Vent.på(() -> {


### PR DESCRIPTION
Det kan oppstå 5058 litt datoavhengig, ellers går testen fram til 5028