### PR TITLE
TFP-6265 automatisk godkjenn uttak der mor er i arbeid

### DIFF
--- a/src/test/java/no/nav/foreldrepenger/autotest/verdikjedetester/VerdikjedeForeldrepenger.java
+++ b/src/test/java/no/nav/foreldrepenger/autotest/verdikjedetester/VerdikjedeForeldrepenger.java
@@ -2416,7 +2416,8 @@ class VerdikjedeForeldrepenger extends VerdikjedeTestBase {
                 .stream()
                 .sorted(Comparator.comparing(DokumentasjonVurderingBehov::tom))
                 .toList();
-        assertThat(vurderingsbehov.getLast().vurdering()).isNull();
+        assertThat(vurderingsbehov.getFirst().vurdering()).isNull(); // Uttaket før mor begynner i arbeid 26 uker etter fødsel
+        assertThat(vurderingsbehov.getLast().vurdering()).isEqualTo(DokumentasjonVurderingBehov.Vurdering.GODKJENT_AUTOMATISK); // Mor i arbeid med 80% stilling
         var førsteVurderingBehov = vurderingsbehov.getFirst();
         vurderUttakDokumentasjonBekreftelse
                 .ikkeGodkjenn(new ÅpenPeriodeDto(førsteVurderingBehov.fom(), førsteVurderingBehov.tom()))


### PR DESCRIPTION
Her er det 10u Minsterett fra F+6u til F+16u, så 20u vanlig uttak F+16u til F+36u.
Mor begynner arbeid F+26 uker. Dermed må de første 10 ukene vurderes mens de siste 10 er automatisk godkjent