### PR TITLE
chore: Ikke sjekk lengden på fpabonnent-logg i fpsak-tester

### DIFF
--- a/.github/workflows/autotest.yml
+++ b/.github/workflows/autotest.yml
@@ -104,6 +104,8 @@ jobs:
             mvn test -e --batch-mode -s settings.xml -Djuipter.parallelism=${{ inputs.parallellitet }} -P loggfeil -DikkeSjekkLengdeAvContainer=fpdokgen,fpabonnent
           elif [[ ${{ inputs.test-suite }} == 'verdikjede' || ${{ inputs.test-suite }} == 'fplos' ]]; then
             mvn test -e --batch-mode -s settings.xml -Djuipter.parallelism=${{ inputs.parallellitet }} -P logger -DikkeSjekkLengdeAvContainer=fpdokgen
+          elif [[ ${{ inputs.test-suite }} == 'fpsak' ]]; then
+            mvn test -e --batch-mode -s settings.xml -Djuipter.parallelism=${{ inputs.parallellitet }} -P logger -DikkeSjekkLengdeAvContainer=fpabonnent
           else
             mvn test -e --batch-mode -s settings.xml -Djuipter.parallelism=${{ inputs.parallellitet }} -P loggfeil
           fi

--- a/pom.xml
+++ b/pom.xml
@@ -26,11 +26,11 @@
 
         <vtp.versjon>2.0.4</vtp.versjon>
         <fp-felles.versjon>7.5.6</fp-felles.versjon>
-        <fp-prosesstask.version>5.1.7</fp-prosesstask.version>
+        <fp-prosesstask.version>5.1.8</fp-prosesstask.version>
         <fp-kontrakter.version>9.3.5</fp-kontrakter.version>
         <fpsoknad-felles.version>3.2.7</fpsoknad-felles.version>
         <foreldrepenge-api.version>0.2.1</foreldrepenge-api.version>
-        <ftberegning.version>5.8.4</ftberegning.version>
+        <ftberegning.version>5.8.5</ftberegning.version>
 
         <slf4j.version>2.0.17</slf4j.version>
         <logback.version>1.5.18</logback.version>


### PR DESCRIPTION
Vet ikke om det har skjedd noe annet enn at en veldig lang linje med all konfig til Avro ikke ble knekt opp med linjeskift
Se logger her https://github.com/navikt/fp-sak/actions/runs/15212498373 - mye \n i oppstarten - tipper det var newline før
Abonnent skal ikke være i aktiv bruk i fpsak-testene