### PR TITLE
Fix substring match in update-versions.sh causing wrong image tag

### DIFF
--- a/pipeline/update-versions.sh
+++ b/pipeline/update-versions.sh
@@ -6,9 +6,9 @@ TRIGGER=${1-not an repo}
 TRIGGER_VERSION=${2-latest}
 
 imageVersion () {
-  if [[ "$TRIGGER" == *"navikt/"* && "$1" == *$TRIGGER* ]]; then
+  if [[ "$TRIGGER" == *"navikt/"* && "$1" == *"$TRIGGER"?(/*) ]]; then
     echo "$1:${TRIGGER_VERSION}"
-  elif [[ "$1" == *"$TRIGGER"* ]]; then
+  elif [[ "$1" == *"$TRIGGER"?(/*) ]]; then
     echo "$TRIGGER:${TRIGGER_VERSION}"
   else
     echo "$1:latest"


### PR DESCRIPTION
## Problem

When verdikjede tests are triggered from another repo (e.g. fp-inntektsmelding), the workflow fails with:
```
manifest for europe-north1-docker.pkg.dev/.../navikt/fp-inntektsmelding-api:<fp-inntektsmelding-version> not found
```

## Root cause

`imageVersion` in `pipeline/update-versions.sh` used the glob `*$TRIGGER*` (substring match). When triggered from `fp-inntektsmelding`, `TRIGGER=navikt/fp-inntektsmelding` matches **both** the `fp-inntektsmelding` image **and** `fp-inntektsmelding-api` / `fp-inntektsmelding-frontend` (since `fp-inntektsmelding` is a substring of those names). All three images then got the same build version, but only fp-inntektsmelding actually has that tag in the registry — pulling the others fails.

## Fix

Tighten the match using extended-glob `*"$TRIGGER"?(/*)`:
- Matches when the image path ends with the trigger (e.g. `.../navikt/fp-inntektsmelding`)
- Matches when followed by a `/sub-image` path (needed for repos like `fp-frontend` that publish multiple sub-images such as `fp-frontend/fp-frontend`, `fp-frontend/fp-avdelingsleder`)
- Does **not** match when followed by `-api`, `-frontend`, etc.

Verified locally:
| Trigger | Result |
|---|---|
| `navikt/fp-inntektsmelding` | only `fp-inntektsmelding` is tagged |
| `navikt/fp-inntektsmelding-api` | only `fp-inntektsmelding-api` is tagged |
| `navikt/fp-frontend` | all three `fp-frontend/*` sub-images tagged |