### PR TITLE
Chore: bruk postgres alpine image som i lokale tester

### DIFF
--- a/pipeline/compose.yml
+++ b/pipeline/compose.yml
@@ -47,7 +47,7 @@ services:
     ports:
       - "127.0.0.1:5999:5999"
     healthcheck:
-      test: [ "CMD-SHELL", "while ! /usr/bin/pg_isready -U admin -t 1; do sleep 1; done" ]
+      test: [ "CMD-SHELL", "while ! pg_isready -U admin -t 1; do sleep 1; done" ]
       interval: 2s
       retries: 10
       timeout: 30s

--- a/pipeline/update-versions.sh
+++ b/pipeline/update-versions.sh
@@ -15,7 +15,7 @@ imageVersion () {
   fi
 }
 
-echo POSTGRES_IMAGE="postgres:18" > .env
+echo POSTGRES_IMAGE="postgres:18-alpine" > .env
 echo ORACLE_IMAGE="gvenzl/oracle-free:23-slim-faststart" >> .env
 echo AUDIT_NAIS_IMAGE="$(imageVersion "europe-north1-docker.pkg.dev/nais-management-233d/teamforeldrepenger/navikt/fp-autotest/audit-nais-mock")" >> .env
 echo VTP_IMAGE="$(imageVersion "europe-north1-docker.pkg.dev/nais-management-233d/teamforeldrepenger/navikt/vtp")" >> .env


### PR DESCRIPTION
Alle koderepos som bruker postgres har 18-alpine. 
Denne endringen gir uniformt oppsett enhetstest, verdikjedetest lokalt og i pipeline