### PR TITLE
TFP-6598 oppdater beregning av AAP og DAGpenger

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,12 +25,12 @@
     <properties>
         <vtp.versjon>2.2.0</vtp.versjon>
 
-        <fp-felles.versjon>7.8.1</fp-felles.versjon>
+        <fp-felles.versjon>7.8.2</fp-felles.versjon>
         <fp-prosesstask.version>5.2.6</fp-prosesstask.version>
         <fp-kontrakter.version>9.4.33</fp-kontrakter.version>
 
-        <ftberegning.version>6.5.5</ftberegning.version>
-        <fpkalkulus.kontrakt.version>1.0.2</fpkalkulus.kontrakt.version>
+        <ftberegning.version>6.6.0</ftberegning.version>
+        <fpkalkulus.kontrakt.version>1.0.3</fpkalkulus.kontrakt.version>
 
         <fpsoknad-kontrakt.version>1.0.4</fpsoknad-kontrakt.version>
 

--- a/src/main/java/no/nav/foreldrepenger/generator/kalkulus/ForeslåBeregningTjeneste.java
+++ b/src/main/java/no/nav/foreldrepenger/generator/kalkulus/ForeslåBeregningTjeneste.java
@@ -43,18 +43,18 @@ public class ForeslåBeregningTjeneste {
         var inntektPrAndelList = årsinntektPrArbeidstakerAndel.entrySet().stream()
                 .map(e -> new InntektPrAndelDto(e.getValue(), e.getKey()))
                 .toList();
-        return new FastsettBeregningsgrunnlagATFLHåndteringDto(inntektPrAndelList, null, List.of());
+        return new FastsettBeregningsgrunnlagATFLHåndteringDto(inntektPrAndelList, null);
     }
 
     public static FastsettBeregningsgrunnlagATFLHåndteringDto fastsettInntektVedAvvik(Map<Long, Integer> årsinntektPrArbeidstakerAndel, Integer frilansinnekt) {
         var inntektPrAndelList = årsinntektPrArbeidstakerAndel.entrySet().stream()
                 .map(e -> new InntektPrAndelDto(e.getValue(), e.getKey()))
                 .toList();
-        return new FastsettBeregningsgrunnlagATFLHåndteringDto(inntektPrAndelList, frilansinnekt, List.of());
+        return new FastsettBeregningsgrunnlagATFLHåndteringDto(inntektPrAndelList, frilansinnekt);
     }
 
     public static FastsettBeregningsgrunnlagATFLHåndteringDto fastsettInntektVedAvvik(Integer frilansinntekt) {
-        return new FastsettBeregningsgrunnlagATFLHåndteringDto(Collections.emptyList(), frilansinntekt, List.of());
+        return new FastsettBeregningsgrunnlagATFLHåndteringDto(Collections.emptyList(), frilansinntekt);
     }
 
     public static VurderVarigEndringEllerNyoppstartetSNHåndteringDto fastsettInntektVarigEndring(Integer beløpPrÅr, boolean erVarigEndring) {

--- a/src/main/resources/kalkulus/besteberegning_for_arbeidstaker_med_dagpenger_i_opptjeningsperioden_bruker_ikke_seks_beste_måneder/input/kalkulator-input.json
+++ b/src/main/resources/kalkulus/besteberegning_for_arbeidstaker_med_dagpenger_i_opptjeningsperioden_bruker_ikke_seks_beste_måneder/input/kalkulator-input.json
@@ -248,6 +248,7 @@
                         }
                     ],
                     "relatertYtelseType": "DAG",
+                    "ytelseKilde": "ARENA",
                     "periode": {
                         "fom": "2019-01-01",
                         "tom": "2019-06-30"

--- a/src/main/resources/kalkulus/besteberegning_for_arbeidstaker_med_dagpenger_i_opptjeningsperioden_bruker_seks_beste_måneder/input/kalkulator-input.json
+++ b/src/main/resources/kalkulus/besteberegning_for_arbeidstaker_med_dagpenger_i_opptjeningsperioden_bruker_seks_beste_måneder/input/kalkulator-input.json
@@ -248,6 +248,7 @@
                         }
                     ],
                     "relatertYtelseType": "DAG",
+                    "ytelseKilde": "ARENA",
                     "periode": {
                         "fom": "2019-01-01",
                         "tom": "2019-06-30"

--- a/src/main/resources/kalkulus/besteberegning_med_dagpenger_på_skjæringstidspunktet/input/kalkulator-input.json
+++ b/src/main/resources/kalkulus/besteberegning_med_dagpenger_på_skjæringstidspunktet/input/kalkulator-input.json
@@ -540,6 +540,7 @@
                         }
                     ],
                     "relatertYtelseType": "DAG",
+                    "ytelseKilde": "ARENA",
                     "periode": {
                         "fom": "2020-03-23",
                         "tom": "2020-05-17"
@@ -549,6 +550,7 @@
                     "vedtaksDagsats": null,
                     "ytelseAnvist": [],
                     "relatertYtelseType": "SP",
+                    "ytelseKilde": "VLSP",
                     "periode": {
                         "fom": "2019-03-21",
                         "tom": "2019-04-04"
@@ -558,6 +560,7 @@
                     "vedtaksDagsats": null,
                     "ytelseAnvist": [],
                     "relatertYtelseType": "SP",
+                    "ytelseKilde": "VLSP",
                     "periode": {
                         "fom": "2019-10-28",
                         "tom": "2019-10-29"
@@ -567,6 +570,7 @@
                     "vedtaksDagsats": null,
                     "ytelseAnvist": [],
                     "relatertYtelseType": "SP",
+                    "ytelseKilde": "VLSP",
                     "periode": {
                         "fom": "2019-12-09",
                         "tom": "2019-12-11"
@@ -576,6 +580,7 @@
                     "vedtaksDagsats": null,
                     "ytelseAnvist": [],
                     "relatertYtelseType": "SP",
+                    "ytelseKilde": "VLSP",
                     "periode": {
                         "fom": "2020-01-22",
                         "tom": "2020-01-29"
@@ -585,6 +590,7 @@
                     "vedtaksDagsats": null,
                     "ytelseAnvist": [],
                     "relatertYtelseType": "SP",
+                    "ytelseKilde": "VLSP",
                     "periode": {
                         "fom": "2020-02-27",
                         "tom": "2020-02-28"
@@ -594,6 +600,7 @@
                     "vedtaksDagsats": null,
                     "ytelseAnvist": [],
                     "relatertYtelseType": "SP",
+                    "ytelseKilde": "VLSP",
                     "periode": {
                         "fom": "2020-03-03",
                         "tom": "2020-03-10"

--- a/src/main/resources/kalkulus/foreldrepenger_arbeidstaker_uten_inntektsmelding_frilans_samme_org/input/kalkulator-input.json
+++ b/src/main/resources/kalkulus/foreldrepenger_arbeidstaker_uten_inntektsmelding_frilans_samme_org/input/kalkulator-input.json
@@ -257,6 +257,7 @@
                         }
                     ],
                     "relatertYtelseType": "SP",
+                    "ytelseKilde": "INFOTRYGD",
                     "periode": {
                         "fom": "2019-03-01",
                         "tom": "2020-01-15"

--- a/src/main/resources/kalkulus/foreldrepenger_at_sn_refusjon_for_virksomhet_med_2_arbeidsforhold_og_overstyring_av_beregningaktiviteter/input/kalkulator-input.json
+++ b/src/main/resources/kalkulus/foreldrepenger_at_sn_refusjon_for_virksomhet_med_2_arbeidsforhold_og_overstyring_av_beregningaktiviteter/input/kalkulator-input.json
@@ -1601,6 +1601,7 @@
                         }
                     ],
                     "relatertYtelseType": "FP",
+                    "ytelseKilde": "FPSAK",
                     "periode": {
                         "fom": "2020-01-01",
                         "tom": "2020-05-29"

--- a/src/main/resources/kalkulus/foreldrepenger_søker_gradering_for_næring_med_arbeid_over_6G/input/kalkulator-input.json
+++ b/src/main/resources/kalkulus/foreldrepenger_søker_gradering_for_næring_med_arbeid_over_6G/input/kalkulator-input.json
@@ -1236,6 +1236,7 @@
                     "vedtaksDagsats": null,
                     "ytelseAnvist": [],
                     "relatertYtelseType": "FP",
+                    "ytelseKilde": "FPSAK",
                     "periode": {
                         "fom": "2019-03-05",
                         "tom": "2020-01-08"
@@ -1255,6 +1256,7 @@
                         }
                     ],
                     "relatertYtelseType": "SVP",
+                    "ytelseKilde": "FPSAK",
                     "periode": {
                         "fom": "2019-02-01",
                         "tom": "2019-03-04"

--- a/src/main/resources/kalkulus/fp_at_sn_med_avvik_beregningsgrunnlag_skal_omfordeles_automatisk_grunnet_refusjon/input/kalkulator-input.json
+++ b/src/main/resources/kalkulus/fp_at_sn_med_avvik_beregningsgrunnlag_skal_omfordeles_automatisk_grunnet_refusjon/input/kalkulator-input.json
@@ -910,6 +910,7 @@
                         }
                     ],
                     "relatertYtelseType": "FP",
+                    "ytelseKilde": "FPSAK",
                     "periode": {
                         "fom": "2019-07-19",
                         "tom": "2020-07-10"
@@ -983,6 +984,7 @@
                         }
                     ],
                     "relatertYtelseType": "FP",
+                    "ytelseKilde": "FPSAK",
                     "periode": {
                         "fom": "2018-01-03",
                         "tom": "2018-01-31"
@@ -1002,6 +1004,7 @@
                         }
                     ],
                     "relatertYtelseType": "FP",
+                    "ytelseKilde": "FPSAK",
                     "periode": {
                         "fom": "2018-07-09",
                         "tom": "2018-07-20"
@@ -1021,6 +1024,7 @@
                         }
                     ],
                     "relatertYtelseType": "PSB",
+                    "ytelseKilde": "K9SAK",
                     "periode": {
                         "fom": "2019-09-18",
                         "tom": "2019-09-25"
@@ -1030,6 +1034,7 @@
                     "vedtaksDagsats": null,
                     "ytelseAnvist": [],
                     "relatertYtelseType": "SP",
+                    "ytelseKilde": "VLSP",
                     "periode": {
                         "fom": "2020-03-16",
                         "tom": "2020-03-20"

--- a/src/main/resources/kalkulus/fp_tilkommet_arbeid_og_fordeling_av_naturalytelse/input/kalkulator-input.json
+++ b/src/main/resources/kalkulus/fp_tilkommet_arbeid_og_fordeling_av_naturalytelse/input/kalkulator-input.json
@@ -1178,6 +1178,7 @@
                         }
                     ],
                     "relatertYtelseType": "FP",
+                    "ytelseKilde": "FPSAK",
                     "periode": {
                         "fom": "2019-12-16",
                         "tom": "2020-08-07"
@@ -1197,6 +1198,7 @@
                         }
                     ],
                     "relatertYtelseType": "SP",
+                    "ytelseKilde": "VLSP",
                     "periode": {
                         "fom": "2019-06-12",
                         "tom": "2019-06-18"
@@ -1206,6 +1208,7 @@
                     "vedtaksDagsats": null,
                     "ytelseAnvist": [],
                     "relatertYtelseType": "SP",
+                    "ytelseKilde": "VLSP",
                     "periode": {
                         "fom": "2019-08-14",
                         "tom": "2019-08-16"
@@ -1252,6 +1255,7 @@
                         }
                     ],
                     "relatertYtelseType": "SP",
+                    "ytelseKilde": "VLSP",
                     "periode": {
                         "fom": "2019-09-27",
                         "tom": "2019-12-13"

--- a/src/main/resources/kalkulus/svp_søkt_refusjon_før_start_av_permisjon_og_avvik/input/kalkulator-input.json
+++ b/src/main/resources/kalkulus/svp_søkt_refusjon_før_start_av_permisjon_og_avvik/input/kalkulator-input.json
@@ -1001,6 +1001,7 @@
                     "vedtaksDagsats": null,
                     "ytelseAnvist": [],
                     "relatertYtelseType": "SP",
+                    "ytelseKilde": "VLSP",
                     "periode": {
                         "fom": "2018-11-01",
                         "tom": "2018-11-09"
@@ -1056,6 +1057,7 @@
                         }
                     ],
                     "relatertYtelseType": "SP",
+                    "ytelseKilde": "VLSP",
                     "periode": {
                         "fom": "2019-09-16",
                         "tom": "2020-01-15"
@@ -1111,6 +1113,7 @@
                         }
                     ],
                     "relatertYtelseType": "SP",
+                    "ytelseKilde": "VLSP",
                     "periode": {
                         "fom": "2019-10-02",
                         "tom": "2020-01-15"

--- a/src/main/resources/kalkulus/svp_tidsbegrenset_at_tilkommet_sn_grunnet_søkt_ytelse/input/kalkulator-input.json
+++ b/src/main/resources/kalkulus/svp_tidsbegrenset_at_tilkommet_sn_grunnet_søkt_ytelse/input/kalkulator-input.json
@@ -724,6 +724,7 @@
                         }
                     ],
                     "relatertYtelseType": "FP",
+                    "ytelseKilde": "FPSAK",
                     "periode": {
                         "fom": "2020-01-08",
                         "tom": "2020-11-10"
@@ -733,6 +734,7 @@
                     "vedtaksDagsats": null,
                     "ytelseAnvist": [],
                     "relatertYtelseType": "SVP",
+                    "ytelseKilde": "FPSAK",
                     "periode": {
                         "fom": "2019-09-19",
                         "tom": "2020-01-07"
@@ -742,6 +744,7 @@
                     "vedtaksDagsats": null,
                     "ytelseAnvist": [],
                     "relatertYtelseType": "FP",
+                    "ytelseKilde": "FPSAK",
                     "periode": {
                         "fom": "2020-01-08",
                         "tom": "2020-01-08"

--- a/src/test/java/no/nav/foreldrepenger/autotest/fpsak/engangsstonad/Adopsjon.java
+++ b/src/test/java/no/nav/foreldrepenger/autotest/fpsak/engangsstonad/Adopsjon.java
@@ -3,7 +3,6 @@ package no.nav.foreldrepenger.autotest.fpsak.engangsstonad;
 import static no.nav.foreldrepenger.generator.familie.generator.PersonGenerator.far;
 import static no.nav.foreldrepenger.generator.familie.generator.PersonGenerator.mor;
 import static no.nav.foreldrepenger.generator.soknad.maler.SøknadEngangsstønadMaler.lagEngangstønadAdopsjon;
-import static no.nav.foreldrepenger.vtp.kontrakter.person.ArbeidsavtaleDto.arbeidsavtale;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalDate;
@@ -23,11 +22,9 @@ import no.nav.foreldrepenger.autotest.klienter.fpsak.behandlinger.dto.aksjonspun
 import no.nav.foreldrepenger.autotest.klienter.fpsak.behandlinger.dto.behandling.AksjonspunktKoder;
 import no.nav.foreldrepenger.autotest.klienter.fpsak.behandlinger.dto.behandling.VilkarTypeKoder;
 import no.nav.foreldrepenger.generator.familie.generator.FamilieGenerator;
-import no.nav.foreldrepenger.generator.familie.generator.InntektYtelseGenerator;
 import no.nav.foreldrepenger.soknad.kontrakt.EngangsstønadDto;
 import no.nav.foreldrepenger.soknad.kontrakt.SøknadDto;
 import no.nav.foreldrepenger.soknad.kontrakt.barn.AdopsjonDto;
-import no.nav.foreldrepenger.vtp.kontrakter.person.ArenaSakerDto;
 import no.nav.foreldrepenger.vtp.kontrakter.person.FamilierelasjonModellDto;
 
 @Tag("fpsak")
@@ -39,14 +36,7 @@ class Adopsjon extends VerdikjedeTestBase {
     @Description("Mor søker adopsjon - godkjent happy case")
     void morSøkerAdopsjonGodkjent() {
         var familie = FamilieGenerator.ny()
-                .forelder(mor()
-                        .inntektytelse(InntektYtelseGenerator.ny()
-                                .arbeidsforhold(LocalDate.now().minusYears(4),
-                                        arbeidsavtale(LocalDate.now().minusYears(4), LocalDate.now().minusDays(60)).build(),
-                                        arbeidsavtale(LocalDate.now().minusDays(59)).stillingsprosent(50).build()
-                                )
-                                .build())
-                        .build())
+                .forelder(mor().build())
                 .forelder(far().build())
                 .relasjonForeldre(FamilierelasjonModellDto.Relasjon.EKTE)
                 .build();
@@ -78,14 +68,7 @@ class Adopsjon extends VerdikjedeTestBase {
     @Description("Mor søker adopsjon - avvist - barn er over 15 år og blir dermed avlått")
     void morSøkerAdopsjonAvvist() {
         var familie = FamilieGenerator.ny()
-                .forelder(mor()
-                        .inntektytelse(InntektYtelseGenerator.ny()
-                                .arbeidsforhold(LocalDate.now().minusYears(4),
-                                        arbeidsavtale(LocalDate.now().minusYears(4), LocalDate.now().minusDays(60)).build(),
-                                        arbeidsavtale(LocalDate.now().minusDays(59)).stillingsprosent(50).build()
-                                )
-                                .build())
-                        .build())
+                .forelder(mor().build())
                 .forelder(far().build())
                 .relasjonForeldre(FamilierelasjonModellDto.Relasjon.EKTE)
                 .build();
@@ -119,14 +102,7 @@ class Adopsjon extends VerdikjedeTestBase {
     @Description("Mor søker adopsjon med overstyrt vilkår som tar behandlingen fra innvilget til avslått")
     void morSøkerAdopsjonOverstyrt() {
         var familie = FamilieGenerator.ny()
-                .forelder(mor()
-                        .inntektytelse(InntektYtelseGenerator.ny()
-                                .arbeidsforhold(LocalDate.now().minusYears(4),
-                                        arbeidsavtale(LocalDate.now().minusYears(4), LocalDate.now().minusDays(60)).build(),
-                                        arbeidsavtale(LocalDate.now().minusDays(59)).stillingsprosent(50).build()
-                                )
-                                .build())
-                        .build())
+                .forelder(mor().build())
                 .forelder(far().build())
                 .relasjonForeldre(FamilierelasjonModellDto.Relasjon.EKTE)
                 .build();
@@ -170,11 +146,7 @@ class Adopsjon extends VerdikjedeTestBase {
     @Description("Far søker adopsjon - godkjent happy case")
     void farSøkerAdopsjonGodkjent() {
         var familie = FamilieGenerator.ny()
-                .forelder(far()
-                        .inntektytelse(InntektYtelseGenerator.ny()
-                                .arena(ArenaSakerDto.YtelseTema.AAP, LocalDate.now().minusMonths(1), LocalDate.now().plusMonths(2), 10_000)
-                                .build())
-                        .build())
+                .forelder(far().build())
                 .forelder(mor().build())
                 .relasjonForeldre(FamilierelasjonModellDto.Relasjon.EKTE)
                 .build();
@@ -207,11 +179,7 @@ class Adopsjon extends VerdikjedeTestBase {
     @Description("Far søker adopsjon av ektefelles barn fører til avvist behandling")
     void farSøkerAdopsjonAvvist() {
         var familie = FamilieGenerator.ny()
-                .forelder(far()
-                        .inntektytelse(InntektYtelseGenerator.ny()
-                                .arena(ArenaSakerDto.YtelseTema.AAP, LocalDate.now().minusMonths(1), LocalDate.now().plusMonths(2), 10_000)
-                                .build())
-                        .build())
+                .forelder(far().build())
                 .forelder(mor().build())
                 .relasjonForeldre(FamilierelasjonModellDto.Relasjon.EKTE)
                 .build();

--- a/src/test/java/no/nav/foreldrepenger/autotest/fpsak/engangsstonad/Fodsel.java
+++ b/src/test/java/no/nav/foreldrepenger/autotest/fpsak/engangsstonad/Fodsel.java
@@ -4,7 +4,6 @@ import static no.nav.foreldrepenger.generator.familie.generator.PersonGenerator.
 import static no.nav.foreldrepenger.generator.familie.generator.PersonGenerator.medmor;
 import static no.nav.foreldrepenger.generator.familie.generator.PersonGenerator.mor;
 import static no.nav.foreldrepenger.generator.soknad.maler.SøknadEngangsstønadMaler.lagEngangstønadFødsel;
-import static no.nav.foreldrepenger.vtp.kontrakter.person.ArbeidsavtaleDto.arbeidsavtale;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalDate;
@@ -29,10 +28,7 @@ import no.nav.foreldrepenger.autotest.klienter.fpsak.behandlinger.dto.aksjonspun
 import no.nav.foreldrepenger.autotest.klienter.fpsak.behandlinger.dto.aksjonspunktbekreftelse.overstyr.OverstyrFodselsvilkaaret;
 import no.nav.foreldrepenger.autotest.klienter.fpsak.behandlinger.dto.behandling.beregning.Beregningsresultat;
 import no.nav.foreldrepenger.generator.familie.generator.FamilieGenerator;
-import no.nav.foreldrepenger.generator.familie.generator.InntektYtelseGenerator;
-import no.nav.foreldrepenger.generator.familie.generator.TestOrganisasjoner;
 import no.nav.foreldrepenger.soknad.kontrakt.builder.BarnBuilder;
-import no.nav.foreldrepenger.vtp.kontrakter.person.ArenaSakerDto;
 import no.nav.foreldrepenger.vtp.kontrakter.person.FamilierelasjonModellDto;
 import no.nav.foreldrepenger.vtp.kontrakter.person.MedlemskapDto;
 import no.nav.foreldrepenger.vtp.kontrakter.person.PersonstatusDto;
@@ -46,9 +42,7 @@ class Fodsel extends VerdikjedeTestBase {
     @Description("Mor søker fødsel - godkjent happy case")
     void morSøkerFødselGodkjent() {
         var familie = FamilieGenerator.ny()
-                .forelder(mor()
-                        .inntektytelse(InntektYtelseGenerator.ny().arbeidMedOpptjeningOver6G().build())
-                        .build())
+                .forelder(mor().build())
                 .forelder(far().build())
                 .relasjonForeldre(FamilierelasjonModellDto.Relasjon.EKTE)
                 .barn(LocalDate.now().minusMonths(1))
@@ -72,14 +66,7 @@ class Fodsel extends VerdikjedeTestBase {
     @Description("Mor søker fødsel - avvist fordi dokumentasjon mangler og barn er ikke registrert i freg")
     void morSøkerFødselAvvist() {
         var familie = FamilieGenerator.ny()
-                .forelder(mor()
-                        .inntektytelse(InntektYtelseGenerator.ny()
-                                .arbeidsforhold(LocalDate.now().minusYears(4),
-                                        arbeidsavtale(LocalDate.now().minusYears(4), LocalDate.now().minusDays(60)).build(),
-                                        arbeidsavtale(LocalDate.now().minusDays(59)).stillingsprosent(50).build()
-                                )
-                                .build())
-                        .build())
+                .forelder(mor().build())
                 .forelder(far().build())
                 .relasjonForeldre(FamilierelasjonModellDto.Relasjon.EKTE)
                 .build();
@@ -115,12 +102,7 @@ class Fodsel extends VerdikjedeTestBase {
     @Description("Far søker registrert fødsel og blir avvist fordi far søker")
     void farSøkerFødselRegistrert() {
         var familie = FamilieGenerator.ny()
-                .forelder(far()
-                        .inntektytelse(InntektYtelseGenerator.ny()
-                                .arbeidsforhold(TestOrganisasjoner.NAV, "ARB001-001", LocalDate.now().minusYears(4), LocalDate.now().minusMonths(4))
-                                .arbeidsforhold(TestOrganisasjoner.NAV, "ARB001-002", LocalDate.now().minusMonths(4))
-                                .build())
-                        .build())
+                .forelder(far().build())
                 .forelder(mor().build())
                 .relasjonForeldre(FamilierelasjonModellDto.Relasjon.EKTE)
                 .barn(LocalDate.now().minusMonths(1))
@@ -148,14 +130,7 @@ class Fodsel extends VerdikjedeTestBase {
     @Description("Mor søker fødsel overstyrt vilkår adopsjon fra godkjent til avslått")
     void morSøkerFødselOverstyrt() {
         var familie = FamilieGenerator.ny()
-                .forelder(mor()
-                        .inntektytelse(InntektYtelseGenerator.ny()
-                                .arbeidsforhold(LocalDate.now().minusYears(4),
-                                        arbeidsavtale(LocalDate.now().minusYears(4), LocalDate.now().minusDays(60)).build(),
-                                        arbeidsavtale(LocalDate.now().minusDays(59)).stillingsprosent(50).build()
-                                )
-                                .build())
-                        .build())
+                .forelder(mor().build())
                 .forelder(far().build())
                 .relasjonForeldre(FamilierelasjonModellDto.Relasjon.EKTE)
                 .build();
@@ -202,7 +177,6 @@ class Fodsel extends VerdikjedeTestBase {
                 .forelder(mor()
                         .personstatus(List.of(new PersonstatusDto(PersonstatusDto.Personstatuser.UTVA, LocalDate.now().minusYears(30), null)))
                         .medlemskap(List.of(new MedlemskapDto(LocalDate.now().minusYears(1), LocalDate.now().plusYears(3), CountryCode.DE, MedlemskapDto.DekningsType.IHT_AVTALE)))
-                        .inntektytelse(InntektYtelseGenerator.ny().arbeidMedOpptjeningOver6G().build())
                         .build())
                 .forelder(far().build())
                 .relasjonForeldre(FamilierelasjonModellDto.Relasjon.EKTE)
@@ -245,11 +219,6 @@ class Fodsel extends VerdikjedeTestBase {
                 .forelder(mor(LocalDate.now().minusYears(17))
                         .personstatus(List.of(new PersonstatusDto(PersonstatusDto.Personstatuser.UTVA, LocalDate.now().minusYears(30), null)))
                         .medlemskap(List.of(new MedlemskapDto(LocalDate.now().minusYears(1), LocalDate.now().plusYears(3), CountryCode.DE, MedlemskapDto.DekningsType.IHT_AVTALE)))
-                        .inntektytelse(InntektYtelseGenerator.ny()
-                                .arena(ArenaSakerDto.YtelseTema.AAP, LocalDate.now().minusMonths(1), LocalDate.now().plusMonths(2), 100_00)
-                                .arbeidsforhold(TestOrganisasjoner.NAV, "ARB001-001", LocalDate.now().minusYears(4), LocalDate.now().minusMonths(4))
-                                .arbeidsforhold(TestOrganisasjoner.NAV, "ARB001-002", LocalDate.now().minusMonths(4))
-                                .build())
                         .build())
                 .forelder(far().build())
                 .relasjonForeldre(FamilierelasjonModellDto.Relasjon.EKTE)
@@ -289,14 +258,7 @@ class Fodsel extends VerdikjedeTestBase {
     @Description("Mor søker uregistrert fødsel mindre enn 14 dager etter fødsel. Behandlingen skal bli satt på vent")
     void morSøkerUregistrertFødselMindreEnn14DagerEtter() {
         var familie = FamilieGenerator.ny()
-                .forelder(mor()
-                        .inntektytelse(InntektYtelseGenerator.ny()
-                                .arbeidsforhold(LocalDate.now().minusYears(4),
-                                        arbeidsavtale(LocalDate.now().minusYears(4), LocalDate.now().minusDays(60)).build(),
-                                        arbeidsavtale(LocalDate.now().minusDays(59)).stillingsprosent(50).build()
-                                )
-                                .build())
-                        .build())
+                .forelder(mor().build())
                 .forelder(far().build())
                 .relasjonForeldre(FamilierelasjonModellDto.Relasjon.EKTE)
                 .build();
@@ -316,9 +278,7 @@ class Fodsel extends VerdikjedeTestBase {
     void medmorSøkerFødsel() {
         var familie = FamilieGenerator.ny()
                 .forelder(mor().build())
-                .forelder(medmor()
-                        .inntektytelse(InntektYtelseGenerator.ny().arbeidMedOpptjeningUnder6G().build())
-                        .build())
+                .forelder(medmor().build())
                 .relasjonForeldre(FamilierelasjonModellDto.Relasjon.EKTE)
                 .barn(LocalDate.now().minusDays(30))
                 .build();

--- a/src/test/java/no/nav/foreldrepenger/autotest/fpsak/engangsstonad/Innsyn.java
+++ b/src/test/java/no/nav/foreldrepenger/autotest/fpsak/engangsstonad/Innsyn.java
@@ -20,7 +20,6 @@ import no.nav.foreldrepenger.autotest.klienter.fpsak.behandlinger.dto.aksjonspun
 import no.nav.foreldrepenger.autotest.klienter.fpsak.historikk.dto.HistorikkType;
 import no.nav.foreldrepenger.autotest.util.AllureHelper;
 import no.nav.foreldrepenger.generator.familie.generator.FamilieGenerator;
-import no.nav.foreldrepenger.generator.familie.generator.InntektYtelseGenerator;
 import no.nav.foreldrepenger.vtp.kontrakter.person.FamilierelasjonModellDto;
 
 @Tag("fpsak")
@@ -32,9 +31,7 @@ class Innsyn extends VerdikjedeTestBase {
     @Description("Behandle innsyn for mor - godkjent happy case")
     void behandleInnsynMorGodkjent() {
         var familie = FamilieGenerator.ny()
-                .forelder(mor()
-                        .inntektytelse(InntektYtelseGenerator.ny().arbeidMedOpptjeningOver6G().build())
-                        .build())
+                .forelder(mor().build())
                 .forelder(far().build())
                 .relasjonForeldre(FamilierelasjonModellDto.Relasjon.EKTE)
                 .barn(LocalDate.now().minusMonths(1))
@@ -78,9 +75,7 @@ class Innsyn extends VerdikjedeTestBase {
     @Description("Behandle innsyn for mor - avvist ved vurdering")
     void behandleInnsynMorAvvist() {
         var familie = FamilieGenerator.ny()
-                .forelder(mor()
-                        .inntektytelse(InntektYtelseGenerator.ny().arbeidMedOpptjeningOver6G().build())
-                        .build())
+                .forelder(mor().build())
                 .forelder(far().build())
                 .relasjonForeldre(FamilierelasjonModellDto.Relasjon.EKTE)
                 .barn(LocalDate.now().minusMonths(1))

--- a/src/test/java/no/nav/foreldrepenger/autotest/fpsak/engangsstonad/Klage.java
+++ b/src/test/java/no/nav/foreldrepenger/autotest/fpsak/engangsstonad/Klage.java
@@ -22,7 +22,6 @@ import no.nav.foreldrepenger.autotest.klienter.fpsak.behandlinger.dto.aksjonspun
 import no.nav.foreldrepenger.autotest.klienter.fpsak.behandlinger.dto.aksjonspunktbekreftelse.VurderingAvKlageNfpBekreftelse;
 import no.nav.foreldrepenger.autotest.klienter.fpsak.behandlinger.dto.behandling.AksjonspunktKoder;
 import no.nav.foreldrepenger.generator.familie.generator.FamilieGenerator;
-import no.nav.foreldrepenger.generator.familie.generator.InntektYtelseGenerator;
 import no.nav.foreldrepenger.kontrakter.felles.typer.Saksnummer;
 import no.nav.foreldrepenger.vtp.kontrakter.person.FamilierelasjonModellDto;
 
@@ -35,9 +34,7 @@ class Klage extends VerdikjedeTestBase {
     @Description("Behandle klage via NFP - vurdert til medhold")
     void klageMedholdNFP() {
         var familie = FamilieGenerator.ny()
-                .forelder(mor()
-                        .inntektytelse(InntektYtelseGenerator.ny().arbeidMedOpptjeningOver6G().build())
-                        .build())
+                .forelder(mor().build())
                 .forelder(far().build())
                 .relasjonForeldre(FamilierelasjonModellDto.Relasjon.EKTE)
                 .barn(LocalDate.now().minusMonths(1))
@@ -89,9 +86,7 @@ class Klage extends VerdikjedeTestBase {
     @Description("Behandle klage via NFP - medhold av NFP avvist av beslutter send tilbake til NFP vurdert til delvist gunst")
     void avvistAvBelutterNFP() {
         var familie = FamilieGenerator.ny()
-                .forelder(mor()
-                        .inntektytelse(InntektYtelseGenerator.ny().arbeidMedOpptjeningOver6G().build())
-                        .build())
+                .forelder(mor().build())
                 .forelder(far().build())
                 .relasjonForeldre(FamilierelasjonModellDto.Relasjon.EKTE)
                 .barn(LocalDate.now().minusMonths(1))

--- a/src/test/java/no/nav/foreldrepenger/autotest/fpsak/engangsstonad/Medlemskap.java
+++ b/src/test/java/no/nav/foreldrepenger/autotest/fpsak/engangsstonad/Medlemskap.java
@@ -27,8 +27,6 @@ import no.nav.foreldrepenger.autotest.klienter.fpsak.behandlinger.dto.aksjonspun
 import no.nav.foreldrepenger.autotest.klienter.fpsak.behandlinger.dto.aksjonspunktbekreftelse.overstyr.OverstyrMedlemskapsvilkaaret;
 import no.nav.foreldrepenger.autotest.klienter.fpsak.behandlinger.dto.behandling.AksjonspunktKoder;
 import no.nav.foreldrepenger.generator.familie.generator.FamilieGenerator;
-import no.nav.foreldrepenger.generator.familie.generator.InntektYtelseGenerator;
-import no.nav.foreldrepenger.vtp.kontrakter.person.ArenaSakerDto;
 import no.nav.foreldrepenger.vtp.kontrakter.person.FamilierelasjonModellDto;
 import no.nav.foreldrepenger.vtp.kontrakter.person.GeografiskTilknytningDto;
 import no.nav.foreldrepenger.vtp.kontrakter.person.MedlemskapDto;
@@ -48,11 +46,6 @@ class Medlemskap extends VerdikjedeTestBase {
                 .forelder(mor()
                         .personstatus(List.of(new PersonstatusDto(PersonstatusDto.Personstatuser.UTVA, LocalDate.now().minusYears(30), null)))
                         .medlemskap(List.of(new MedlemskapDto(LocalDate.now().minusYears(1), LocalDate.now().plusYears(3), CountryCode.DE, MedlemskapDto.DekningsType.IHT_AVTALE)))
-                        .inntektytelse(InntektYtelseGenerator.ny()
-                                .arena(ArenaSakerDto.YtelseTema.AAP, LocalDate.now().minusMonths(1), LocalDate.now().plusMonths(2), 10_000)
-                                .arbeidsforhold(LocalDate.now().minusYears(4), LocalDate.now().minusMonths(4))
-                                .arbeidsforhold(LocalDate.now().minusMonths(4))
-                                .arbeidMedOpptjeningOver6G().build())
                         .build())
                 .forelder(far().build())
                 .relasjonForeldre(FamilierelasjonModellDto.Relasjon.EKTE)

--- a/src/test/java/no/nav/foreldrepenger/autotest/fpsak/engangsstonad/Revurdering.java
+++ b/src/test/java/no/nav/foreldrepenger/autotest/fpsak/engangsstonad/Revurdering.java
@@ -3,7 +3,6 @@ package no.nav.foreldrepenger.autotest.fpsak.engangsstonad;
 import static no.nav.foreldrepenger.generator.familie.generator.PersonGenerator.far;
 import static no.nav.foreldrepenger.generator.familie.generator.PersonGenerator.mor;
 import static no.nav.foreldrepenger.generator.soknad.maler.SøknadEngangsstønadMaler.lagEngangstønadAdopsjon;
-import static no.nav.foreldrepenger.vtp.kontrakter.person.ArbeidsavtaleDto.arbeidsavtale;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalDate;
@@ -25,7 +24,6 @@ import no.nav.foreldrepenger.autotest.klienter.fpsak.behandlinger.dto.aksjonspun
 import no.nav.foreldrepenger.autotest.klienter.fpsak.behandlinger.dto.behandling.AksjonspunktKoder;
 import no.nav.foreldrepenger.autotest.klienter.fpsak.historikk.dto.HistorikkType;
 import no.nav.foreldrepenger.generator.familie.generator.FamilieGenerator;
-import no.nav.foreldrepenger.generator.familie.generator.InntektYtelseGenerator;
 import no.nav.foreldrepenger.vtp.kontrakter.person.FamilierelasjonModellDto;
 
 @Tag("fpsak")
@@ -37,14 +35,7 @@ class Revurdering extends VerdikjedeTestBase {
     @Description("Manuelt opprettet revurdering etter avsluttet behandling med utsendt varsel")
     void manueltOpprettetRevurderingSendVarsel() {
         var familie = FamilieGenerator.ny()
-                .forelder(mor()
-                        .inntektytelse(InntektYtelseGenerator.ny()
-                                .arbeidsforhold(LocalDate.now().minusYears(4),
-                                        arbeidsavtale(LocalDate.now().minusYears(4), LocalDate.now().minusDays(60)).build(),
-                                        arbeidsavtale(LocalDate.now().minusDays(59)).stillingsprosent(50).build()
-                                )
-                                .build())
-                        .build())
+                .forelder(mor().build())
                 .forelder(far().build())
                 .relasjonForeldre(FamilierelasjonModellDto.Relasjon.EKTE)
                 .build();

--- a/src/test/java/no/nav/foreldrepenger/autotest/fpsak/engangsstonad/Soknadsfrist.java
+++ b/src/test/java/no/nav/foreldrepenger/autotest/fpsak/engangsstonad/Soknadsfrist.java
@@ -3,7 +3,6 @@ package no.nav.foreldrepenger.autotest.fpsak.engangsstonad;
 import static no.nav.foreldrepenger.generator.familie.generator.PersonGenerator.far;
 import static no.nav.foreldrepenger.generator.familie.generator.PersonGenerator.mor;
 import static no.nav.foreldrepenger.generator.soknad.maler.SøknadEngangsstønadMaler.lagEngangstønadFødsel;
-import static no.nav.foreldrepenger.vtp.kontrakter.person.ArbeidsavtaleDto.arbeidsavtale;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalDate;
@@ -21,7 +20,6 @@ import no.nav.foreldrepenger.autotest.klienter.fpsak.behandlinger.dto.aksjonspun
 import no.nav.foreldrepenger.autotest.klienter.fpsak.behandlinger.dto.aksjonspunktbekreftelse.avklarfakta.SjekkManglendeFødselBekreftelse;
 import no.nav.foreldrepenger.autotest.klienter.fpsak.behandlinger.dto.behandling.AksjonspunktKoder;
 import no.nav.foreldrepenger.generator.familie.generator.FamilieGenerator;
-import no.nav.foreldrepenger.generator.familie.generator.InntektYtelseGenerator;
 import no.nav.foreldrepenger.vtp.kontrakter.person.FamilierelasjonModellDto;
 
 @Tag("foreldrepenger")
@@ -32,14 +30,7 @@ class Soknadsfrist extends VerdikjedeTestBase {
     @Description("Behandle søknadsfrist og sent tilbake på grunn av søknadsfrist. Manglende fødsel.")
     void behandleSøknadsfristOgSentTilbakePåGrunnAvSøknadsfrist() {
         var familie = FamilieGenerator.ny()
-                .forelder(mor()
-                        .inntektytelse(InntektYtelseGenerator.ny()
-                                .arbeidsforhold(LocalDate.now().minusYears(4),
-                                        arbeidsavtale(LocalDate.now().minusYears(4), LocalDate.now().minusDays(60)).build(),
-                                        arbeidsavtale(LocalDate.now().minusDays(59)).stillingsprosent(50).build()
-                                )
-                                .build())
-                        .build())
+                .forelder(mor().build())
                 .forelder(far().build())
                 .relasjonForeldre(FamilierelasjonModellDto.Relasjon.EKTE)
                 .build();
@@ -84,14 +75,7 @@ class Soknadsfrist extends VerdikjedeTestBase {
     @Description("Behandle søknadsfrist og sent tilbake på grunn av fødsel - tester tilbakesending")
     void behandleSøknadsfristOgSentTilbakePåGrunnAvFodsel() {
         var familie = FamilieGenerator.ny()
-                .forelder(mor()
-                        .inntektytelse(InntektYtelseGenerator.ny()
-                                .arbeidsforhold(LocalDate.now().minusYears(4),
-                                        arbeidsavtale(LocalDate.now().minusYears(4), LocalDate.now().minusDays(60)).build(),
-                                        arbeidsavtale(LocalDate.now().minusDays(59)).stillingsprosent(50).build()
-                                )
-                                .build())
-                        .build())
+                .forelder(mor().build())
                 .forelder(far().build())
                 .relasjonForeldre(FamilierelasjonModellDto.Relasjon.EKTE)
                 .build();

--- a/src/test/java/no/nav/foreldrepenger/autotest/fpsak/engangsstonad/Termin.java
+++ b/src/test/java/no/nav/foreldrepenger/autotest/fpsak/engangsstonad/Termin.java
@@ -3,7 +3,6 @@ package no.nav.foreldrepenger.autotest.fpsak.engangsstonad;
 import static no.nav.foreldrepenger.generator.familie.generator.PersonGenerator.far;
 import static no.nav.foreldrepenger.generator.familie.generator.PersonGenerator.mor;
 import static no.nav.foreldrepenger.generator.soknad.maler.SøknadEngangsstønadMaler.lagEngangstønadTermin;
-import static no.nav.foreldrepenger.vtp.kontrakter.person.ArbeidsavtaleDto.arbeidsavtale;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalDate;
@@ -25,8 +24,6 @@ import no.nav.foreldrepenger.autotest.klienter.fpsak.behandlinger.dto.aksjonspun
 import no.nav.foreldrepenger.autotest.klienter.fpsak.behandlinger.dto.aksjonspunktbekreftelse.overstyr.OverstyrFodselsvilkaaret;
 import no.nav.foreldrepenger.autotest.klienter.fpsak.behandlinger.dto.behandling.AksjonspunktKoder;
 import no.nav.foreldrepenger.generator.familie.generator.FamilieGenerator;
-import no.nav.foreldrepenger.generator.familie.generator.InntektYtelseGenerator;
-import no.nav.foreldrepenger.vtp.kontrakter.person.ArenaSakerDto;
 import no.nav.foreldrepenger.vtp.kontrakter.person.FamilierelasjonModellDto;
 
 @Tag("fpsak")
@@ -38,14 +35,7 @@ class Termin extends VerdikjedeTestBase {
     @Description("Mor søker termin - godkjent happy case")
     void morSøkerTerminGodkjent() {
         var familie = FamilieGenerator.ny()
-                .forelder(mor()
-                        .inntektytelse(InntektYtelseGenerator.ny()
-                                .arbeidsforhold(LocalDate.now().minusYears(4),
-                                        arbeidsavtale(LocalDate.now().minusYears(4), LocalDate.now().minusDays(60)).build(),
-                                        arbeidsavtale(LocalDate.now().minusDays(59)).stillingsprosent(50).build()
-                                )
-                                .build())
-                        .build())
+                .forelder(mor().build())
                 .forelder(far().build())
                 .relasjonForeldre(FamilierelasjonModellDto.Relasjon.EKTE)
                 .build();
@@ -80,14 +70,7 @@ class Termin extends VerdikjedeTestBase {
     @Description("Mor søker termin overstyrt vilkår fødsel fra oppfylt til avvist")
     void morSøkerTerminOvertyrt() {
         var familie = FamilieGenerator.ny()
-                .forelder(mor()
-                        .inntektytelse(InntektYtelseGenerator.ny()
-                                .arbeidsforhold(LocalDate.now().minusYears(4),
-                                        arbeidsavtale(LocalDate.now().minusYears(4), LocalDate.now().minusDays(60)).build(),
-                                        arbeidsavtale(LocalDate.now().minusDays(59)).stillingsprosent(50).build()
-                                )
-                                .build())
-                        .build())
+                .forelder(mor().build())
                 .forelder(far().build())
                 .relasjonForeldre(FamilierelasjonModellDto.Relasjon.EKTE)
                 .build();
@@ -132,11 +115,7 @@ class Termin extends VerdikjedeTestBase {
     @Description("Far søker termin avslått pga søker er far")
     void farSøkerTermin() {
         var familie = FamilieGenerator.ny()
-                .forelder(far()
-                        .inntektytelse(InntektYtelseGenerator.ny()
-                                .arena(ArenaSakerDto.YtelseTema.AAP, LocalDate.now().minusMonths(1), LocalDate.now().plusMonths(2), 10_000)
-                                .build())
-                        .build())
+                .forelder(far().build())
                 .forelder(mor().build())
                 .relasjonForeldre(FamilierelasjonModellDto.Relasjon.EKTE)
                 .build();
@@ -162,14 +141,7 @@ class Termin extends VerdikjedeTestBase {
     @Description("Setter behandling på vent og gjennoptar og henlegger")
     void settBehandlingPåVentOgGjenopptaOgHenlegg() {
         var familie = FamilieGenerator.ny()
-                .forelder(mor()
-                        .inntektytelse(InntektYtelseGenerator.ny()
-                                .arbeidsforhold(LocalDate.now().minusYears(4),
-                                        arbeidsavtale(LocalDate.now().minusYears(4), LocalDate.now().minusDays(60)).build(),
-                                        arbeidsavtale(LocalDate.now().minusDays(59)).stillingsprosent(50).build()
-                                )
-                                .build())
-                        .build())
+                .forelder(mor().build())
                 .forelder(far().build())
                 .relasjonForeldre(FamilierelasjonModellDto.Relasjon.EKTE)
                 .build();
@@ -204,14 +176,7 @@ class Termin extends VerdikjedeTestBase {
     @Description("Mor søker termin 25 dager etter fødsel - Får aksjonpunkt om manglende fødsel - godkjent")
     void morSøkerTermin25DagerTilbakeITid() {
         var familie = FamilieGenerator.ny()
-                .forelder(mor()
-                        .inntektytelse(InntektYtelseGenerator.ny()
-                                .arbeidsforhold(LocalDate.now().minusYears(4),
-                                        arbeidsavtale(LocalDate.now().minusYears(4), LocalDate.now().minusDays(60)).build(),
-                                        arbeidsavtale(LocalDate.now().minusDays(59)).stillingsprosent(50).build()
-                                )
-                                .build())
-                        .build())
+                .forelder(mor().build())
                 .forelder(far().build())
                 .relasjonForeldre(FamilierelasjonModellDto.Relasjon.EKTE)
                 .build();

--- a/src/test/java/no/nav/foreldrepenger/autotest/fpsak/foreldrepenger/BeregningVerdikjede.java
+++ b/src/test/java/no/nav/foreldrepenger/autotest/fpsak/foreldrepenger/BeregningVerdikjede.java
@@ -17,10 +17,6 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 
-import no.nav.foreldrepenger.autotest.domain.foreldrepenger.PeriodeResultatType;
-import no.nav.foreldrepenger.autotest.klienter.fpsak.behandlinger.dto.behandling.uttak.UttakResultatPeriode;
-import no.nav.foreldrepenger.kontrakter.fpoversikt.Inntektskilde;
-
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
@@ -31,6 +27,7 @@ import no.nav.foreldrepenger.autotest.base.VerdikjedeTestBase;
 import no.nav.foreldrepenger.autotest.domain.foreldrepenger.AktivitetStatus;
 import no.nav.foreldrepenger.autotest.domain.foreldrepenger.BehandlingResultatType;
 import no.nav.foreldrepenger.autotest.domain.foreldrepenger.Inntektskategori;
+import no.nav.foreldrepenger.autotest.domain.foreldrepenger.PeriodeResultatType;
 import no.nav.foreldrepenger.autotest.klienter.fpsak.behandlinger.dto.aksjonspunktbekreftelse.FatterVedtakBekreftelse;
 import no.nav.foreldrepenger.autotest.klienter.fpsak.behandlinger.dto.aksjonspunktbekreftelse.FordelBeregningsgrunnlagBekreftelse;
 import no.nav.foreldrepenger.autotest.klienter.fpsak.behandlinger.dto.aksjonspunktbekreftelse.ForeslåVedtakBekreftelse;
@@ -41,6 +38,7 @@ import no.nav.foreldrepenger.autotest.klienter.fpsak.behandlinger.dto.behandling
 import no.nav.foreldrepenger.autotest.klienter.fpsak.behandlinger.dto.behandling.beregning.beregningsgrunnlag.Beregningsgrunnlag;
 import no.nav.foreldrepenger.autotest.klienter.fpsak.behandlinger.dto.behandling.beregning.beregningsgrunnlag.BeregningsgrunnlagPeriodeDto;
 import no.nav.foreldrepenger.autotest.klienter.fpsak.behandlinger.dto.behandling.beregning.beregningsgrunnlag.BeregningsgrunnlagPrStatusOgAndelDto;
+import no.nav.foreldrepenger.autotest.klienter.fpsak.behandlinger.dto.behandling.uttak.UttakResultatPeriode;
 import no.nav.foreldrepenger.autotest.klienter.fpsak.historikk.dto.HistorikkType;
 import no.nav.foreldrepenger.generator.familie.generator.FamilieGenerator;
 import no.nav.foreldrepenger.generator.familie.generator.InntektYtelseGenerator;
@@ -49,9 +47,10 @@ import no.nav.foreldrepenger.generator.inntektsmelding.builders.Inntektsmelding;
 import no.nav.foreldrepenger.generator.inntektsmelding.builders.Prosent;
 import no.nav.foreldrepenger.generator.soknad.maler.AnnenforelderMaler;
 import no.nav.foreldrepenger.generator.soknad.maler.OpptjeningMaler;
-import no.nav.foreldrepenger.soknad.kontrakt.BrukerRolle;
-import no.nav.foreldrepenger.kontrakter.felles.typer.Orgnummer;
 import no.nav.foreldrepenger.kontrakter.felles.kodeverk.KontoType;
+import no.nav.foreldrepenger.kontrakter.felles.typer.Orgnummer;
+import no.nav.foreldrepenger.kontrakter.fpoversikt.Inntektskilde;
+import no.nav.foreldrepenger.soknad.kontrakt.BrukerRolle;
 import no.nav.foreldrepenger.vtp.kontrakter.person.ArenaSakerDto;
 import no.nav.foreldrepenger.vtp.kontrakter.person.FamilierelasjonModellDto;
 import no.nav.foreldrepenger.vtp.kontrakter.person.GrunnlagDto;
@@ -161,6 +160,7 @@ class BeregningVerdikjede extends VerdikjedeTestBase {
                 lagBGAndelMedFordelt(aapAndel.getAktivitetStatus().getKode(), totaltBg, 0, 0));
         verifiserAndelerIPeriode(beregningsgrunnlag.getBeregningsgrunnlagPeriode(1),
                 lagBGAndelMedFordelt(new Orgnummer(arbeidsgiver.arbeidsgiverIdentifikator()), 0, totaltBg, totaltBg, inntektPerMåned * 12));
+        assertThat(aapAndel.getDagsats()).isEqualTo(1000);
     }
 
 
@@ -209,7 +209,7 @@ class BeregningVerdikjede extends VerdikjedeTestBase {
                 .filter(a -> a.getAktivitetStatus().equals(AktivitetStatus.ARBEIDSAVKLARINGSPENGER))
                 .findFirst().orElseThrow();
         assertThat(arbeidsandel.getDagsats()).isEqualTo(1731);
-        assertThat(aapAndel.getDagsats()).isEqualTo(1000);
+        assertThat(aapAndel.getDagsats()).isEqualTo(500);
     }
 
 

--- a/src/test/java/no/nav/foreldrepenger/autotest/fptilbake/engangsstonad/TilbakekrevingES.java
+++ b/src/test/java/no/nav/foreldrepenger/autotest/fptilbake/engangsstonad/TilbakekrevingES.java
@@ -25,18 +25,14 @@ import no.nav.foreldrepenger.autotest.klienter.fpsak.behandlinger.dto.aksjonspun
 import no.nav.foreldrepenger.autotest.klienter.fpsak.behandlinger.dto.aksjonspunktbekreftelse.VurderOmsorgsovertakelseVilkårAksjonspunktDto;
 import no.nav.foreldrepenger.autotest.klienter.fpsak.behandlinger.dto.aksjonspunktbekreftelse.avklarfakta.AvklarFaktaVergeBekreftelse;
 import no.nav.foreldrepenger.autotest.klienter.fpsak.behandlinger.dto.aksjonspunktbekreftelse.avklarfakta.VurderMedlemskapsvilkårForutgåendeBekreftelse;
-import no.nav.foreldrepenger.soknad.kontrakt.barn.AdopsjonDto;
-import no.nav.foreldrepenger.soknad.kontrakt.EngangsstønadDto;
 import no.nav.foreldrepenger.autotest.klienter.fptilbake.behandlinger.dto.aksjonspunktbekrefter.ApFaktaFeilutbetaling;
 import no.nav.foreldrepenger.autotest.klienter.fptilbake.behandlinger.dto.aksjonspunktbekrefter.ApVerge;
 import no.nav.foreldrepenger.autotest.klienter.fptilbake.behandlinger.dto.aksjonspunktbekrefter.ApVilkårsvurdering;
 import no.nav.foreldrepenger.autotest.klienter.fptilbake.behandlinger.dto.aksjonspunktbekrefter.FattVedtakTilbakekreving;
 import no.nav.foreldrepenger.autotest.klienter.fptilbake.okonomi.dto.Kravgrunnlag;
 import no.nav.foreldrepenger.generator.familie.generator.FamilieGenerator;
-import no.nav.foreldrepenger.generator.familie.generator.InntektYtelseGenerator;
-import no.nav.foreldrepenger.generator.familie.generator.TestOrganisasjoner;
-import no.nav.foreldrepenger.vtp.kontrakter.person.ArbeidsavtaleDto;
-import no.nav.foreldrepenger.vtp.kontrakter.person.ArenaSakerDto;
+import no.nav.foreldrepenger.soknad.kontrakt.EngangsstønadDto;
+import no.nav.foreldrepenger.soknad.kontrakt.barn.AdopsjonDto;
 import no.nav.foreldrepenger.vtp.kontrakter.person.FamilierelasjonModellDto;
 import no.nav.foreldrepenger.vtp.kontrakter.person.MedlemskapDto;
 import no.nav.foreldrepenger.vtp.kontrakter.person.PersonstatusDto;
@@ -52,14 +48,7 @@ class TilbakekrevingES extends FptilbakeTestBase {
     @Description("Vanligste scenario, enkel periode, treffer ikke foreldelse, full tilbakekreving.")
     void opprettTilbakekrevingManuelt() {
         var familie = FamilieGenerator.ny()
-                .forelder(mor()
-                        .inntektytelse(InntektYtelseGenerator.ny()
-                                .arbeidsforhold(LocalDate.now().minusYears(4), 1_120_000,
-                                        ArbeidsavtaleDto.arbeidsavtale(LocalDate.now().minusYears(4), LocalDate.now().minusDays(60)).build(),
-                                        ArbeidsavtaleDto.arbeidsavtale(LocalDate.now().minusDays(59)).stillingsprosent(50).build()
-                                )
-                        .build())
-                        .build())
+                .forelder(mor().build())
                 .forelder(far().build())
                 .relasjonForeldre(FamilierelasjonModellDto.Relasjon.EKTE)
                 .build();
@@ -159,11 +148,6 @@ class TilbakekrevingES extends FptilbakeTestBase {
                 .forelder(mor(LocalDate.now().minusYears(17))
                         .personstatus(List.of(new PersonstatusDto(PersonstatusDto.Personstatuser.UTVA, LocalDate.now().minusYears(30), null)))
                         .medlemskap(List.of(new MedlemskapDto(LocalDate.now().minusYears(1), LocalDate.now().plusYears(3), CountryCode.DE, MedlemskapDto.DekningsType.IHT_AVTALE)))
-                        .inntektytelse(InntektYtelseGenerator.ny()
-                                .arena(ArenaSakerDto.YtelseTema.AAP, LocalDate.now().minusMonths(1), LocalDate.now().plusMonths(2), 100_00)
-                                .arbeidsforhold(TestOrganisasjoner.NAV, "ARB001-001", LocalDate.now().minusYears(4), LocalDate.now().minusMonths(4))
-                                .arbeidsforhold(TestOrganisasjoner.NAV, "ARB001-002", LocalDate.now().minusMonths(4))
-                                .build())
                         .build())
                 .forelder(far().build())
                 .relasjonForeldre(FamilierelasjonModellDto.Relasjon.EKTE)

--- a/src/test/java/no/nav/foreldrepenger/autotest/verdikjedetester/VerdikjedeEngangsstonad.java
+++ b/src/test/java/no/nav/foreldrepenger/autotest/verdikjedetester/VerdikjedeEngangsstonad.java
@@ -20,10 +20,9 @@ import no.nav.foreldrepenger.autotest.klienter.fpsak.behandlinger.dto.aksjonspun
 import no.nav.foreldrepenger.autotest.klienter.fpsak.behandlinger.dto.aksjonspunktbekreftelse.avklarfakta.VurderMedlemskapsvilkårForutgåendeBekreftelse;
 import no.nav.foreldrepenger.autotest.klienter.fpsak.historikk.dto.DokumentTag;
 import no.nav.foreldrepenger.autotest.klienter.fpsak.historikk.dto.HistorikkType;
-import no.nav.foreldrepenger.kontrakter.fpoversikt.BehandlingTilstand;
 import no.nav.foreldrepenger.generator.familie.generator.FamilieGenerator;
-import no.nav.foreldrepenger.generator.familie.generator.InntektYtelseGenerator;
 import no.nav.foreldrepenger.generator.soknad.maler.SøknadEngangsstønadMaler;
+import no.nav.foreldrepenger.kontrakter.fpoversikt.BehandlingTilstand;
 import no.nav.foreldrepenger.vtp.kontrakter.person.FamilierelasjonModellDto;
 import no.nav.foreldrepenger.vtp.kontrakter.person.StatsborgerskapDto;
 
@@ -36,7 +35,6 @@ class VerdikjedeEngangsstonad extends VerdikjedeTestBase {
     void MorTredjelandsborgerSøkerEngangsStønadTest() {
         var familie = FamilieGenerator.ny()
                 .forelder(mor().statsborgerskap(List.of(new StatsborgerskapDto(CountryCode.US)))
-                        .inntektytelse(InntektYtelseGenerator.ny().arbeidMedOpptjeningUnder6G().build())
                         .build())
                 .forelder(far().build())
                 .relasjonForeldre(FamilierelasjonModellDto.Relasjon.EKTE)
@@ -74,7 +72,6 @@ class VerdikjedeEngangsstonad extends VerdikjedeTestBase {
     void mor_innsyn_verifsere() {
         var familie = FamilieGenerator.ny()
                 .forelder(mor().statsborgerskap(List.of(new StatsborgerskapDto(CountryCode.US)))
-                        .inntektytelse(InntektYtelseGenerator.ny().arbeidMedOpptjeningUnder6G().build())
                         .build())
                 .forelder(far().build())
                 .relasjonForeldre(FamilierelasjonModellDto.Relasjon.EKTE)

--- a/src/test/java/no/nav/foreldrepenger/autotest/verdikjedetester/VerdikjedeForeldrepenger.java
+++ b/src/test/java/no/nav/foreldrepenger/autotest/verdikjedetester/VerdikjedeForeldrepenger.java
@@ -71,10 +71,6 @@ import java.time.temporal.ChronoUnit;
 import java.util.Comparator;
 import java.util.List;
 
-import no.nav.foreldrepenger.generator.inntektsmelding.builders.Inntektsmelding;
-
-import no.nav.foreldrepenger.generator.inntektsmelding.builders.InntektsmeldingBuilder;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -131,6 +127,7 @@ import no.nav.foreldrepenger.generator.familie.Familie;
 import no.nav.foreldrepenger.generator.familie.generator.FamilieGenerator;
 import no.nav.foreldrepenger.generator.familie.generator.InntektYtelseGenerator;
 import no.nav.foreldrepenger.generator.familie.generator.TestOrganisasjoner;
+import no.nav.foreldrepenger.generator.inntektsmelding.builders.Inntektsmelding;
 import no.nav.foreldrepenger.generator.inntektsmelding.builders.Prosent;
 import no.nav.foreldrepenger.generator.soknad.maler.AnnenforelderMaler;
 import no.nav.foreldrepenger.generator.soknad.maler.OpptjeningMaler;
@@ -881,7 +878,7 @@ class VerdikjedeForeldrepenger extends VerdikjedeTestBase {
         var familie = FamilieGenerator.ny()
                 .forelder(mor().inntektytelse(InntektYtelseGenerator.ny().arbeidMedOpptjeningOver6G().build()).build())
                 .forelder(far().inntektytelse(InntektYtelseGenerator.ny()
-                        .arena(ArenaSakerDto.YtelseTema.AAP, LocalDate.now().minusMonths(12), LocalDate.now().plusMonths(2), ytelseFar)
+                        .arena(ArenaSakerDto.YtelseTema.AAP, LocalDate.now().minusMonths(12), LocalDate.now().plusMonths(2), 10000)
                         .build()).build())
                 .relasjonForeldre(FamilierelasjonModellDto.Relasjon.EKTE)
                 .barn(LocalDate.now().minusWeeks(6))
@@ -1176,11 +1173,10 @@ class VerdikjedeForeldrepenger extends VerdikjedeTestBase {
     @Description("Mor søker med dagpenger som grunnlag. Kvalifiserer til automatisk besteberegning."
             + "Beregning etter etter §14-7, 3. ledd gir høyere inntekt enn beregning etter §14-7, 1. ledd")
     void MorSøkerMedDagpengerTest() {
-        var ytelseMor = 260_000;
         var familie = FamilieGenerator.ny()
                 .forelder(mor().inntektytelse(InntektYtelseGenerator.ny()
                         .arbeidsforhold(LocalDate.now().minusMonths(10), LocalDate.now().minusMonths(5).minusDays(1))
-                        .arena(ArenaSakerDto.YtelseTema.DAG, LocalDate.now().minusMonths(5), LocalDate.now().minusWeeks(5), ytelseMor)
+                        .arena(ArenaSakerDto.YtelseTema.DAG, LocalDate.now().minusMonths(5), LocalDate.now().minusWeeks(5), 10000)
                         .build()).build())
                 .forelder(far().build())
                 .relasjonForeldre(FamilierelasjonModellDto.Relasjon.EKTE)


### PR DESCRIPTION
En materiell endring i beregningverdikjede: En assert som feilaktig forventet full dagsats er nå justert til halv dagsats.
Forøvrig: Endringer som følge av nye versjoner, samt fjerner IAY fra alle ES-testene siden ES ikke innhenter IAY 
Merges sammen med fpsak og kalkulus. Da først vil testene passere. 