### PR TITLE
fix: add /api suffix to frontend integration URLs

### DIFF
--- a/pipeline/common.env
+++ b/pipeline/common.env
@@ -16,11 +16,11 @@ FPLOS_OVERRIDE_URL=http://fplos:8080/fplos
 FPDOKGEN_OVERRIDE_URL=http://fpdokgen:8080/fpdokgen
 
 #### FRONTEND INTEGRASJONER ####
-FPOVERSIKT_API_URL=http://fpoversikt:8080/fpoversikt
+FPOVERSIKT_API_URL=http://fpoversikt:8080/fpoversikt/api
 FPOVERSIKT_API_SCOPE=lokal
-FPSOKNAD_API_URL=http://fpsoknad:8080/fpsoknad
+FPSOKNAD_API_URL=http://fpsoknad:8080/fpsoknad/api
 FPSOKNAD_API_SCOPE=lokal
-FPGRUNNDATA_API_URL=http://fpgrunndata:8080/fpgrunndata
+FPGRUNNDATA_API_URL=http://fpgrunndata:8080/fpgrunndata/api
 
 #### EKSTERNE INTEGRASJONER ####
 ##### SOAP #####


### PR DESCRIPTION
Endrer for å fungere med Steffen sin endring for å gjøre selvbetjening proxy strengere (kun api paths)

---
Match the URL format expected by foreldrepengesoknad's reverse proxy. The server mounts proxy middleware at /fpoversikt/api etc., and Express strips that prefix before forwarding to target, so target must include the /api path segment.