### PR TITLE
Legg til Maskinporten miljøvariabler i common.env

### DIFF
--- a/pipeline/common.env
+++ b/pipeline/common.env
@@ -209,6 +209,27 @@ IDPORTEN_CLIENT_JWK="
       \"n\": \"jAQFAKQ9omNtb_I2iSryCulJnkB56qGf35fA1RrDBLup7ysJCez9dnu-HTZ62SKoe-9Pxu-4WzjjBNQacotUXYTIi7GFWM5Pyb4ha-bBJprbiwhyrYGIVzZw4LIcleexWPcIOI0cTKmpM6qKb9_6CTFa-A6uX_16n-n3fQjWGPKrJBY7mcIalJ4YTmLhavs6yt6efSD67SaJ2FabzjouRa_yeDmsGPq2LA-4FymDvuGCHeeMtPO9ClnA2eWC15L7n3-Pagm5pso5GchORl2Rwr_bhCmNCKsC_Qh6TqTHJyymuJwZIuSOv88cf-5UsSidRSJ9r0dBl0S0KgndCagD6Q\"
     }"
 
+#MASKINPORTEN
+MASKINPORTEN_CLIENT_ID=vtp
+MASKINPORTEN_ISSUER=http://vtp/rest/maskinporten
+MASKINPORTEN_TOKEN_ENDPOINT=http://vtp:8060/rest/maskinporten/token
+MASKINPORTEN_SCOPES=digdir:dialogporten.serviceprovider
+MASKINPORTEN_CLIENT_JWK="
+    {
+      \"p\": \"2dZeNRmZow7uWKzqpOolNf7FUIr6dP5bThwnqpcDca7sP96fzPGaryZmYAawZj7h1UthpDp9b2D5v0-D0fSrbdp-MisaOz_ZL-2kdwyTSIP0ii-4yPHpFqaZuGTbuLmROwDhklTGMoYC4fN8vb0jgE6cR33bA52JH255qz5R1rc\",
+      \"kty\": \"RSA\",
+      \"q\": \"pIt7sgMqDPGZDMiksZ19R9iuUZk5ZcsnPeI0yAGIaEp75Nc7IH9F1LQ8mPw-wtV3Yde26mByszjeskVfldlReZmzeCTXq4jgu5WEi2GM7craTZj-ES7SLkuP21uvbgxGCLxEizr4RCdZD8TtkxcSG2-GPkp-N4IX9187kvWbWl8\",
+      \"d\": \"R_P82iKNJflwkPnpOr5eGmtekLvTq1cZwJ7M0vbox3LlVmpIP9iRPKVEwuBva0ybRu1pkvM4S3DFgYK6gKjHVzPYl6lHvKZxbFyP8lJoaj1km2NhA3cwqJjqkx4VAJhLlEuG5wDlTSRXNpzqfamdZcH-XMG2rM-nh6yFqbSzyaeO99ZnGMDp5mZvzGuR0VmV6IXPXqelP4uT9cPQD60h1v2DaOKlmd-0ghGfdHa0hzR5S8C55oZ5hF1_bhgx6tA8VzC1jp41mDbKmKAOKvcFG2T9JQRBml2izRVVaCsVN0_ZCR7NhQYrkreqgVN_ZLlgzI6YSA2EN1FWmc9GvNFAbQ\",
+      \"e\": \"AQAB\",
+      \"use\": \"sig\",
+      \"kid\": \"ut-Fle8JH9IdPqo7QDDakblWR1DdvMIijJT9A-lVntk\",
+      \"qi\": \"uoncSFVC9_vS652rNSZQO8I7KCk0b2bpt38Sb1iQ8Vha5lYkrTp-AsZLoduj7TscCCqlftm9R-FkfERjEYZLdPKQIaGcCQ-L0RzIG_K3w48Tk2T_EEiMqds4UeBpQxccMjUvX-t_b7pwMjFL1RIEBSWAxg5YShT8C83hv0llh9Y\",
+      \"dp\": \"BLMxWSfyPqhl0Bf7AA_lOaMDktdMzBVo1uiYmn-jnWJOypn9DKjx03Gap9u9Fpeou7dipe51ImAPQ2dtyqvivv4F1wNDD6AzCWuxLrhgvSHLtueMrxk5FDoH-wiCDRxD2-gK9eNKW3C0wzdDq7xW9b-8c3ZtsUhG2xzBF0bC8UU\",
+      \"alg\": \"RS256\",
+      \"dq\": \"R_ji4BhWOlcq9NaGg1I5zEVQ6kw1OPtFbOIW6C0Td1qtGomySSKibslvgBNFeH9auqdaUOZjBVWowx1pE-h8pM3AHJsw4sz6T9K0qSrAM_r4xdxXtThfovRWNkLCV0ZzE7sV2DixA06avDUNHbuHpgyAEZsP3kO_K-qx6jQYAc0\",
+      \"n\": \"jAQFAKQ9omNtb_I2iSryCulJnkB56qGf35fA1RrDBLup7ysJCez9dnu-HTZ62SKoe-9Pxu-4WzjjBNQacotUXYTIi7GFWM5Pyb4ha-bBJprbiwhyrYGIVzZw4LIcleexWPcIOI0cTKmpM6qKb9_6CTFa-A6uX_16n-n3fQjWGPKrJBY7mcIalJ4YTmLhavs6yt6efSD67SaJ2FabzjouRa_yeDmsGPq2LA-4FymDvuGCHeeMtPO9ClnA2eWC15L7n3-Pagm5pso5GchORl2Rwr_bhCmNCKsC_Qh6TqTHJyymuJwZIuSOv88cf-5UsSidRSJ9r0dBl0S0KgndCagD6Q\"
+    }"
+
 # Nais variabler
 NAIS_CLUSTER_NAME=vtp
 NAIS_NAMESPACE=teamforeldrepenger


### PR DESCRIPTION
Legger til MASKINPORTEN_CLIENT_ID, MASKINPORTEN_CLIENT_JWK, MASKINPORTEN_SCOPES, MASKINPORTEN_ISSUER og MASKINPORTEN_TOKEN_ENDPOINT i pipeline/common.env.

Disse trengs av fp-inntektsmelding for Dialogporten-integrasjonen via Maskinporten. Uten disse feiler MaskinportenTokenKlient med NullPointerException ved oppstart av token-flyt.

Avhengighet: navikt/vtp#... (maskinporten token-endepunkt)