### PR TITLE
TFP-6942: fiks SVP-tilretteleggings-DTO-er i autotest som har divergert fra fpsak

### DIFF
--- a/src/main/java/no/nav/foreldrepenger/autotest/klienter/fpsak/behandlinger/dto/aksjonspunktbekreftelse/avklarfakta/AvklarFaktaFødselOgTilrettelegging.java
+++ b/src/main/java/no/nav/foreldrepenger/autotest/klienter/fpsak/behandlinger/dto/aksjonspunktbekreftelse/avklarfakta/AvklarFaktaFødselOgTilrettelegging.java
@@ -1,19 +1,19 @@
 package no.nav.foreldrepenger.autotest.klienter.fpsak.behandlinger.dto.aksjonspunktbekreftelse.avklarfakta;
 
-import java.time.LocalDate;
-import java.util.List;
-
 import no.nav.foreldrepenger.autotest.klienter.fpsak.behandlinger.dto.aksjonspunktbekreftelse.AksjonspunktBekreftelse;
 import no.nav.foreldrepenger.autotest.klienter.fpsak.behandlinger.dto.behandling.Behandling;
 import no.nav.foreldrepenger.autotest.klienter.fpsak.behandlinger.dto.behandling.svangerskapspenger.Arbeidsforhold;
 import no.nav.foreldrepenger.autotest.klienter.fpsak.fagsak.dto.Fagsak;
 import no.nav.foreldrepenger.generator.familie.ArbeidsforholdId;
 
+import java.time.LocalDate;
+import java.util.List;
+
 public class AvklarFaktaFødselOgTilrettelegging extends AksjonspunktBekreftelse {
 
     protected LocalDate termindato;
     protected LocalDate fødselsdato;
-    protected List<Arbeidsforhold> bekreftetSvpArbeidsforholdList;
+    protected List<BekreftTilrettelegging> bekreftetSvpArbeidsforholdList;
 
     @Override
     public String aksjonspunktKode() {
@@ -24,10 +24,22 @@ public class AvklarFaktaFødselOgTilrettelegging extends AksjonspunktBekreftelse
     public void oppdaterMedDataFraBehandling(Fagsak fagsak, Behandling behandling) {
         this.termindato = behandling.getTilrettelegging().getTermindato();
         this.fødselsdato = behandling.getTilrettelegging().getFødselsdato();
-        this.bekreftetSvpArbeidsforholdList = behandling.getTilrettelegging().getArbeidsforholdList();
+        this.bekreftetSvpArbeidsforholdList = behandling.getTilrettelegging().getArbeidsforholdList().stream().map(this::mapTilArbeidsforhold).toList();
     }
 
-    public List<Arbeidsforhold> getBekreftetSvpArbeidsforholdList() {
+    private BekreftTilrettelegging mapTilArbeidsforhold(Arbeidsforhold a) {
+        var tilrettelegging = new BekreftTilrettelegging();
+        tilrettelegging.setArbeidsgiverReferanse(a.getArbeidsgiverReferanse());
+        tilrettelegging.setTilretteleggingId(a.getTilretteleggingId());
+        tilrettelegging.setSkalBrukes(a.getSkalBrukes());
+        tilrettelegging.setTilretteleggingBehovFom(a.getTilretteleggingBehovFom());
+        tilrettelegging.setTilretteleggingDatoer(a.getTilretteleggingDatoer());
+        tilrettelegging.setAvklarteOppholdPerioder(a.getAvklarteOppholdPerioder());
+        tilrettelegging.setInternArbeidsforholdReferanse(a.getInternArbeidsforholdReferanse());
+        return tilrettelegging;
+    }
+
+    public List<BekreftTilrettelegging> getBekreftetSvpArbeidsforholdList() {
         return bekreftetSvpArbeidsforholdList;
     }
 

--- a/src/main/java/no/nav/foreldrepenger/autotest/klienter/fpsak/behandlinger/dto/aksjonspunktbekreftelse/avklarfakta/BekreftTilrettelegging.java
+++ b/src/main/java/no/nav/foreldrepenger/autotest/klienter/fpsak/behandlinger/dto/aksjonspunktbekreftelse/avklarfakta/BekreftTilrettelegging.java
@@ -1,0 +1,120 @@
+package no.nav.foreldrepenger.autotest.klienter.fpsak.behandlinger.dto.aksjonspunktbekreftelse.avklarfakta;
+
+import jakarta.validation.Valid;
+import no.nav.foreldrepenger.autotest.klienter.fpsak.behandlinger.dto.behandling.svangerskapspenger.AvklartOpphold;
+import no.nav.foreldrepenger.autotest.klienter.fpsak.behandlinger.dto.behandling.svangerskapspenger.Tilretteleggingsdato;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+public class BekreftTilrettelegging {
+
+    private Long tilretteleggingId;
+    private LocalDate tilretteleggingBehovFom;
+    private List<@Valid Tilretteleggingsdato> tilretteleggingDatoer = new ArrayList<>();
+    private String arbeidsgiverReferanse;
+    private UUID internArbeidsforholdReferanse;
+    private String eksternArbeidsforholdReferanse;
+    private boolean skalBrukes = true;
+    private boolean kanTilrettelegges = true;
+    private BigDecimal stillingsprosentStartTilrettelegging;
+    private List<@Valid AvklartOpphold> avklarteOppholdPerioder = new ArrayList<>();
+
+    private String begrunnelse;
+
+    public LocalDate getTilretteleggingBehovFom() {
+        return tilretteleggingBehovFom;
+    }
+
+    public void setTilretteleggingBehovFom(LocalDate tilretteleggingBehovFom) {
+        this.tilretteleggingBehovFom = tilretteleggingBehovFom;
+    }
+
+    public List<Tilretteleggingsdato> getTilretteleggingDatoer() {
+        return tilretteleggingDatoer;
+    }
+
+    public void setTilretteleggingDatoer(List<Tilretteleggingsdato> tilretteleggingDatoer) {
+        this.tilretteleggingDatoer = tilretteleggingDatoer;
+    }
+
+    public Long getTilretteleggingId() {
+        return tilretteleggingId;
+    }
+
+    public void setTilretteleggingId(Long tilretteleggingId) {
+        this.tilretteleggingId = tilretteleggingId;
+    }
+
+    public String getBegrunnelse() {
+        return begrunnelse;
+    }
+
+    public void setBegrunnelse(String begrunnelse) {
+        this.begrunnelse = begrunnelse;
+    }
+
+    public UUID getInternArbeidsforholdReferanse() {
+        return internArbeidsforholdReferanse;
+    }
+
+    public void setInternArbeidsforholdReferanse(UUID internArbeidsforholdRef) {
+        this.internArbeidsforholdReferanse = internArbeidsforholdRef;
+    }
+
+    public boolean getSkalBrukes() {
+        return skalBrukes;
+    }
+
+    public void setSkalBrukes(boolean skalBrukes) {
+        this.skalBrukes = skalBrukes;
+    }
+
+    public List<AvklartOpphold> getAvklarteOppholdPerioder() {
+        return avklarteOppholdPerioder;
+    }
+
+    public void setAvklarteOppholdPerioder(List<AvklartOpphold> avklarteOppholdPerioder) {
+        this.avklarteOppholdPerioder = avklarteOppholdPerioder;
+    }
+
+    public boolean isKanTilrettelegges() {
+        return kanTilrettelegges;
+    }
+
+    public void setKanTilrettelegges(boolean kanTilrettelegges) {
+        this.kanTilrettelegges = kanTilrettelegges;
+    }
+
+    public String getEksternArbeidsforholdReferanse() {
+        return eksternArbeidsforholdReferanse;
+    }
+
+    public void setEksternArbeidsforholdReferanse(String eksternArbeidsforholdReferanse) {
+        this.eksternArbeidsforholdReferanse = eksternArbeidsforholdReferanse;
+    }
+
+
+    public void leggTilAvklarteOppholdPerioder(List<AvklartOpphold> avklarteOppholdPerioder) {
+        avklarteOppholdPerioder.forEach(oppholdPeriode -> this.avklarteOppholdPerioder.add(oppholdPeriode));
+    }
+
+    public String getArbeidsgiverReferanse() {
+        return arbeidsgiverReferanse;
+    }
+
+    public void setArbeidsgiverReferanse(String arbeidsgiverReferanse) {
+        this.arbeidsgiverReferanse = arbeidsgiverReferanse;
+    }
+
+    public BigDecimal getStillingsprosentStartTilrettelegging() {
+        return stillingsprosentStartTilrettelegging;
+    }
+
+    public void setStillingsprosentStartTilrettelegging(BigDecimal stillingsprosentStartTilrettelegging) {
+        this.stillingsprosentStartTilrettelegging = stillingsprosentStartTilrettelegging;
+    }
+}

--- a/src/main/java/no/nav/foreldrepenger/autotest/klienter/fpsak/behandlinger/dto/behandling/svangerskapspenger/Arbeidsforhold.java
+++ b/src/main/java/no/nav/foreldrepenger/autotest/klienter/fpsak/behandlinger/dto/behandling/svangerskapspenger/Arbeidsforhold.java
@@ -1,9 +1,9 @@
 package no.nav.foreldrepenger.autotest.klienter.fpsak.behandlinger.dto.behandling.svangerskapspenger;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
@@ -11,19 +11,34 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 public class Arbeidsforhold {
 
     protected List<AvklartOpphold> avklarteOppholdPerioder;
-    protected Integer tilretteleggingId;
+    protected Long tilretteleggingId;
     protected LocalDate tilretteleggingBehovFom;
     protected List<Tilretteleggingsdato> tilretteleggingDatoer = new ArrayList<>();
-    protected String arbeidsgiverNavn;
-    protected String arbeidsgiverIdent;
-    protected String opplysningerOmRisiko;
-    protected String opplysningerOmTilrettelegging;
-    protected Boolean kopiertFraTidligereBehandling;
-    protected LocalDateTime mottattTidspunkt;
-    protected String internArbeidsforholdReferanse;
+    protected String arbeidsgiverReferanse;
+    protected UUID internArbeidsforholdReferanse;
     protected String eksternArbeidsforholdReferanse;
     protected Boolean skalBrukes;
     protected String begrunnelse;
+
+    public List<Tilretteleggingsdato> getTilretteleggingDatoer() {
+        return tilretteleggingDatoer;
+    }
+
+    public void setTilretteleggingDatoer(List<Tilretteleggingsdato> tilretteleggingDatoer) {
+        this.tilretteleggingDatoer = tilretteleggingDatoer;
+    }
+
+    public LocalDate getTilretteleggingBehovFom() {
+        return tilretteleggingBehovFom;
+    }
+
+    public void setTilretteleggingBehovFom(LocalDate tilretteleggingBehovFom) {
+        this.tilretteleggingBehovFom = tilretteleggingBehovFom;
+    }
+
+    public Long getTilretteleggingId() {
+        return tilretteleggingId;
+    }
 
     public Boolean getSkalBrukes() {
         return skalBrukes;
@@ -33,17 +48,15 @@ public class Arbeidsforhold {
         this.skalBrukes = skalBrukes;
     }
 
+    public String getArbeidsgiverReferanse() {
+        return arbeidsgiverReferanse;
+    }
+
     public String getEksternArbeidsforholdReferanse() {
         return eksternArbeidsforholdReferanse;
     }
 
-    public void setTilretteleggingBehovFom(LocalDate tilretteleggingBehovFom) {this.tilretteleggingBehovFom = tilretteleggingBehovFom;}
-
-    public void setTilretteleggingDatoer(List<Tilretteleggingsdato> tilretteleggingDatoer) {
-        this.tilretteleggingDatoer = tilretteleggingDatoer;
-    }
-
-    public String getInternArbeidsforholdReferanse() {
+    public UUID getInternArbeidsforholdReferanse() {
         return internArbeidsforholdReferanse;
     }
 


### PR DESCRIPTION
## Bakgrunn                                                                                                                                                                                                                                                                                          
Verdikjedetestene for svangerskapspenger-tilrettelegging feilet når vi merget https://github.com/navikt/fp-sak/pull/7901.

## Problem                                                                                                                                                                                                                                                                                           
DTO-ene i fpsak og autotest har divergert over tid. Grunnen til at dette ikke har blitt oppdaget tidligere er at vi ikke har hatt tilstrekkelig validering i BekreftSvangerskapspengerOppdaterer. 
Konkret har DTO-ene for Arbeidsforhold (autotest) / SvpArbeidsforhold (fpsak) divergert. I tillegg har fpsak ulike DTO-er opp og ned mot frontend (SvpArbeidsforhold og BekreftTilrettelegging). Dette gjorde at når autotest forsøkte å bruke feltene direkte fra Arbeidsforhold til å bekrefte    aksjonspunktet, ble mange av feltene ansett som `null`, fordi de har ulike navn.                                                                                                                                                                                                      

## Endringer                                                                                                                                                                                                                                                                                         
- BekreftTilrettelegging: er opprettet i autotest og speiler den i fpsak  
- AvklarFaktaFødselOgTilrettelegging: mapper nå arbeidsforholdene eksplisitt over til BekreftTilrettelegging slik at riktige felter blir satt ved bekreftelse.                                                                                
- Arbeidsforhold (svangerskapspenger): rettet feltene slik at de matcher fpsak igjen – tilretteleggingId (Integer → Long), internArbeidsforholdReferanse (String → UUID), lagt til arbeidsgiverReferanse, og fjernet utdaterte felter som ikke lenger brukes.
- oppdatert ft-beregning til 7.0.1
                                                                                                                                                                                                                                                        
## Verifisering                                                                                                                                                                                                                                                                                      
   - mvn test-compile → BUILD SUCCESS                                                                                                                                                                                                                                                               
   - Testene er uendret; kun DTO-mappingen er rettet.        