### PR TITLE
Fiks manglende anførselstegn i services-array i scheduled-report

### DIFF
--- a/.github/workflows/scheduled-report.yml
+++ b/.github/workflows/scheduled-report.yml
@@ -39,7 +39,7 @@ jobs:
         id: setup
         shell: bash
         run: |
-          services=("fpsak" "fpformidling" "fpdokgen" "fpoppdrag" "fptilbake" "fprisk" "fpmottak" "fpsoknad" "fpoversikt" "fpkalkulus" "fpinntektsmelding" "fplos" "fpinntektsmeldingapi)
+          services=("fpsak" "fpformidling" "fpdokgen" "fpoppdrag" "fptilbake" "fprisk" "fpmottak" "fpsoknad" "fpoversikt" "fpkalkulus" "fpinntektsmelding" "fplos" "fpinntektsmeldingapi")
           cd pipeline
           ./update-versions.sh
           echo "Kjører docker compose up på følgende applikasjoner: ${services[*]}"


### PR DESCRIPTION
## Bakgrunn

Denne workflowen har feilet siden i 5. mai

## Fiks

Retter et manglende avsluttende anførselstegn på `fpinntektsmeldingapi` i services-array (linje 42) i `.github/workflows/scheduled-report.yml`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>